### PR TITLE
Add Microsoft Teams notification integration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,8 @@
 ![PowerShell](https://img.shields.io/badge/PowerShell-5.1+-5391FE?logo=make&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-launchd-000000?logo=apple&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-Task_Scheduler-0078D4?logo=task&logoColor=white)
+![Teams](https://img.shields.io/badge/Microsoft_Teams-Webhook-6264A7?logo=microsoftteams&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-Version_Control-F05032?logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
@@ -32,7 +34,8 @@ The system is cross-platform, supporting macOS (launchd) and Windows (Task Sched
 8. [Error Handling](#8-error-handling)
 9. [File System Layout](#9-file-system-layout)
 10. [Security Considerations](#10-security-considerations)
-11. [Future Enhancements / Extension Points](#11-future-enhancements--extension-points)
+11. [Teams Notification Pipeline](#11-teams-notification-pipeline)
+12. [Future Enhancements / Extension Points](#12-future-enhancements--extension-points)
 
 ---
 
@@ -57,6 +60,14 @@ graph TD
         F --> G[Notion Page - AI Daily Briefing]
     end
 
+    subgraph "Post-Processing"
+        B1 -->|On success| T1[notify-teams.sh]
+        B2 -->|On success| T2[notify-teams.ps1]
+        T1 --> TC[build-teams-card.py]
+        T2 --> TC
+        TC -->|Adaptive Card JSON| TW[Teams Webhook]
+    end
+
     B1 -->|Writes logs| H[logs/ Directory]
     B2 -->|Writes logs| H
 ```
@@ -68,6 +79,7 @@ graph TD
 - **Single responsibility.** Each file has one job: scheduling, orchestration, prompt definition, or installation.
 - **Cost containment.** A hard budget cap of $2.00 per run prevents runaway API costs.
 - **Observability.** All output (stdout and stderr) is captured in date-stamped log files.
+- **Multi-channel delivery.** Briefings publish to Notion and optionally post to Microsoft Teams via webhook.
 
 ---
 
@@ -103,6 +115,9 @@ sequenceDiagram
     participant W as WebSearch Tool
     participant N as Notion MCP Tool
     participant NP as Notion Page
+    participant T as notify-teams.sh / .ps1
+    participant P as build-teams-card.py
+    participant TW as Teams Webhook
 
     Note over S: Automatic trigger at 08:00<br/>or manual trigger
     S->>E: Execute entry script
@@ -127,6 +142,12 @@ sequenceDiagram
 
     C-->>E: Output with page URL
     E->>E: Log success or failure
+    E->>E: Check AI_BRIEFING_TEAMS_WEBHOOK
+    E->>T: notify-teams.sh / .ps1
+    T->>P: build-teams-card.py (parse log)
+    P-->>T: Adaptive Card JSON
+    T->>TW: POST to Teams webhook
+    TW-->>T: 200 OK
     E->>E: Clean up logs older than 30 days
 ```
 
@@ -322,6 +343,67 @@ graph LR
 Located at `~/.local/bin/ai-news` on macOS, this is a convenience script for on-demand execution. It calls `launchctl kickstart` to trigger the same launchd job, reusing the exact execution environment defined in the plist.
 
 On Windows, the equivalent is `schtasks /run /tn AiNewsBriefing`, or simply `make run` on either platform.
+
+### 3.9 Teams Notification Pipeline
+
+After a successful briefing run, the system can optionally post a summary to a Microsoft Teams channel via a Power Automate webhook. The notification pipeline uses a three-file architecture: a platform-native shell script dispatches to a shared Python builder, which produces an Adaptive Card JSON payload for the webhook.
+
+```mermaid
+flowchart LR
+    L["logs/YYYY-MM-DD.log"] -->|Input| NS["notify-teams.sh / .ps1"]
+    NS -->|Invokes| PY["build-teams-card.py"]
+    PY -->|Parses sections, bullets, sources| AC["Adaptive Card JSON"]
+    AC -->|POST| WH["Teams Webhook URL"]
+    WH -->|200 OK| NS
+```
+
+#### Files Involved
+
+| File | Language | Purpose |
+|---|---|---|
+| `scripts/notify-teams.sh` | Bash | macOS/Linux entry point. Validates log, checks webhook env var, calls Python builder, POSTs via `curl`. |
+| `scripts/notify-teams.ps1` | PowerShell | Windows entry point. Same logic as the Bash variant using `Invoke-RestMethod`. |
+| `scripts/build-teams-card.py` | Python 3 | Shared card builder. Parses the log file and emits an Adaptive Card JSON payload to stdout. |
+
+#### Adaptive Card Structure
+
+The card is built as an [Adaptive Card v1.4](https://adaptivecards.io/) with the following layout:
+
+1. **Header banner.** An accent-styled container with a newspaper icon, the title "AI Daily Briefing", the date, and a story/topic count.
+2. **Section blocks.** Each briefing topic gets a separator, an icon (matched via `ICON_MAP` keyword lookup), a bold header, and its bullet points.
+3. **Sources.** If the log contains `[title](url)` links, they are collected into a collapsible sources section at the bottom.
+4. **Full-width rendering.** The card sets `"msteams": {"width": "Full"}` to use the entire channel width instead of the narrow default.
+
+The card is wrapped in the Teams message envelope:
+
+```json
+{
+  "type": "message",
+  "attachments": [{
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "content": { "type": "AdaptiveCard", "version": "1.4", "msteams": {"width": "Full"}, "body": [...] }
+  }]
+}
+```
+
+#### Environment Variable Setup
+
+The webhook URL is read from the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable. If the variable is not set, the notification step is skipped silently.
+
+**macOS / Linux:**
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+export AI_BRIEFING_TEAMS_WEBHOOK="https://prod-XX.westus.logic.azure.com:443/workflows/..."
+```
+
+**Windows (PowerShell):**
+
+```powershell
+[Environment]::SetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "https://prod-XX.westus.logic.azure.com:443/workflows/...", "User")
+```
+
+Both scripts also accept command-line overrides (`--webhook-url` / `-WebhookUrl`) for testing without modifying the environment.
 
 ---
 
@@ -590,7 +672,9 @@ graph TD
     SC --> SC2["log-summary.sh/.ps1"]
     SC --> SC3["dry-run.sh/.ps1"]
     SC --> SC4["topic-edit.sh/.ps1"]
-    SC --> SC5["+ 8 more pairs"]
+    SC --> SC5["notify-teams.sh/.ps1"]
+    SC --> SC6["build-teams-card.py"]
+    SC --> SC7["+ 8 more pairs"]
     A --> B[briefing.sh]
     A --> B2[briefing.ps1]
     A --> C[prompt.md]
@@ -632,6 +716,9 @@ graph TD
 | `.gitignore` | Shared | Excludes `logs/`, `*.log`, `.DS_Store` | Yes |
 | `ARCHITECTURE.md` | Shared | This document | Yes |
 | `README.md` | Shared | User-facing documentation | Yes |
+| `scripts/notify-teams.sh` | macOS/Linux | Teams notification entry point (Bash) | Yes |
+| `scripts/notify-teams.ps1` | Windows | Teams notification entry point (PowerShell) | Yes |
+| `scripts/build-teams-card.py` | Shared | Adaptive Card JSON builder (Python 3) | Yes |
 | `scripts/*.sh` | macOS/Linux | Utility scripts (12 tools) | Yes |
 | `scripts/*.ps1` | Windows | Utility scripts (12 tools) | Yes |
 | `logs/*.log` | Shared | Daily run logs | No (gitignored) |
@@ -683,7 +770,13 @@ No secrets are stored in any tracked file. Claude Code's API key and Notion inte
 
 ---
 
-## 11. Future Enhancements / Extension Points
+## 11. Teams Notification Pipeline
+
+See [Section 3.9](#39-teams-notification-pipeline) for full architectural details.
+
+---
+
+## 12. Future Enhancements / Extension Points
 
 ### Adding or Modifying Topics
 
@@ -695,12 +788,13 @@ Change `--model sonnet` in the entry script for your platform. Consider adjustin
 
 ### Adding Notification Channels
 
-| Channel | Implementation Approach |
-|---|---|
-| macOS notification | `osascript -e 'display notification ...'` in `briefing.sh` |
-| Windows toast | `New-BurntToastNotification` or `[Windows.UI.Notifications]` in `briefing.ps1` |
-| Slack | Slack MCP tool call in `prompt.md` or webhook `curl`/`Invoke-RestMethod` in the entry script |
-| Email | `mail`/`sendmail` (macOS) or `Send-MailMessage` (Windows) in the entry script |
+| Channel | Status | Implementation Approach |
+|---|---|---|
+| Microsoft Teams | **Implemented** | Power Automate webhook + Adaptive Card via `notify-teams.sh/.ps1` and `build-teams-card.py`. See [Section 3.9](#39-teams-notification-pipeline). |
+| macOS notification | Planned | `osascript -e 'display notification ...'` in `briefing.sh` |
+| Windows toast | Planned | `New-BurntToastNotification` or `[Windows.UI.Notifications]` in `briefing.ps1` |
+| Slack | Planned | Slack MCP tool call in `prompt.md` or webhook `curl`/`Invoke-RestMethod` in the entry script |
+| Email | Planned | `mail`/`sendmail` (macOS) or `Send-MailMessage` (Windows) in the entry script |
 
 ### Adding Linux Support
 
@@ -737,6 +831,8 @@ The log files follow a predictable naming convention (`YYYY-MM-DD.log`) and cont
 | Cost report | -- | `bash scripts/cost-report.sh` | `.\scripts\cost-report.ps1` |
 | Backup prompt | -- | `bash scripts/backup-prompt.sh --backup` | `.\scripts\backup-prompt.ps1 -Action backup` |
 | Edit topics | -- | `bash scripts/topic-edit.sh --list` | `.\scripts\topic-edit.ps1 -Action list` |
+| Test Teams notify | -- | `bash scripts/notify-teams.sh` | `.\scripts\notify-teams.ps1` |
+| Set Teams webhook | -- | `export AI_BRIEFING_TEAMS_WEBHOOK="..."` | `[Environment]::SetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "...", "User")` |
 
 ### Environment Requirements
 

--- a/NOTIFY_TEAMS.md
+++ b/NOTIFY_TEAMS.md
@@ -1,0 +1,450 @@
+# Microsoft Teams Integration: Adaptive Card Notifications
+
+![Microsoft Teams](https://img.shields.io/badge/Microsoft_Teams-Notifications-6264A7?logo=microsoftteams&logoColor=white)
+![Power Automate](https://img.shields.io/badge/Power_Automate-Webhook-0066FF?logo=powerautomate&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.8+-3776AB?logo=python&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-Script-4EAA25?logo=gnubash&logoColor=white)
+![PowerShell](https://img.shields.io/badge/PowerShell-5.1+-5391FE?logo=make&logoColor=white)
+
+This document describes the Microsoft Teams notification feature -- an optional post-run step that sends a rich Adaptive Card summary of the daily briefing to a Teams channel via a Power Automate webhook.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [Setup: Creating the Webhook in Teams](#3-setup-creating-the-webhook-in-teams)
+4. [Setting the Environment Variable](#4-setting-the-environment-variable)
+5. [How It Works](#5-how-it-works)
+6. [Testing](#6-testing)
+7. [Adaptive Card Format](#7-adaptive-card-format)
+8. [Troubleshooting](#8-troubleshooting)
+9. [Files Involved](#9-files-involved)
+
+---
+
+## 1. Overview
+
+After a successful briefing run, the entry point scripts (`briefing.sh` on macOS, `briefing.ps1` on Windows) call a platform-native notification script (`notify-teams.sh` or `notify-teams.ps1`). Those scripts invoke a shared Python script (`scripts/build-teams-card.py`) that parses the run's log file, builds a Microsoft Adaptive Card JSON payload, and POSTs it to a Power Automate webhook URL.
+
+The result is a rich, interactive summary card delivered directly to your Teams channel -- giving the team immediate visibility into the daily briefing without opening Notion.
+
+### Why it exists
+
+Not everyone on a team checks Notion first thing in the morning. Teams is where conversations happen, so pushing a structured summary there ensures the briefing reaches people where they already are. The Adaptive Card format provides a scannable overview with clickable source links and a direct button to the full briefing in Notion.
+
+---
+
+## 2. Prerequisites
+
+| Requirement | Details |
+|---|---|
+| **Microsoft Teams** | A Teams workspace where you have permission to add workflows to a channel |
+| **Power Automate** | Access to the Workflows app in Teams (included with most Microsoft 365 plans) |
+| **Python 3.8+** | Required to run `scripts/build-teams-card.py` -- must be accessible as `python3` (macOS/Linux) or `python` (Windows) |
+| **Webhook URL** | A Power Automate webhook URL for your target Teams channel (setup instructions below) |
+| **A completed briefing run** | The notification parses a log file, so at least one successful run must exist in `logs/` |
+
+---
+
+## 3. Setup: Creating the Webhook in Teams
+
+> **Important:** The legacy "Incoming Webhook" connector in Teams is deprecated and will stop working. Use the Power Automate Workflows approach described below instead.
+
+There are two ways to create the webhook. Both produce the same result -- a URL that accepts HTTP POST requests and delivers an Adaptive Card to your channel.
+
+### Option A: From the Channel Context Menu (Recommended)
+
+This is the fastest path if you just want alerts in a specific channel.
+
+1. In Microsoft Teams, navigate to the channel where you want notifications.
+2. Click the **ellipsis (...)** next to the channel name to open the context menu.
+3. Select **Workflows**.
+4. Search for and select the **"Post to a channel when a webhook request is received"** template.
+5. Give the workflow a name (e.g., `AI Briefing Notification`).
+6. Confirm the target channel.
+7. Click **Add workflow**.
+8. Copy the webhook URL that is displayed -- you will need this for the environment variable.
+
+### Option B: From Scratch in the Workflows App
+
+Use this approach if the template is not available in your tenant or you want more control over the flow.
+
+1. Open the **Workflows** app in Teams (click the Apps icon in the left sidebar, search for "Workflows").
+2. Click **Create** to build a new flow from scratch.
+3. **Trigger:** Search for and select **"When a Teams webhook request is received"**.
+4. **Action:** Add the action **"Post card in a chat or channel"**.
+   - **Post as:** Flow bot
+   - **Post in:** Channel
+   - **Team:** Select your team
+   - **Channel:** Select the target channel
+   - **Adaptive Card:** Use the dynamic content from the trigger (the body of the incoming webhook request)
+5. Save the flow.
+6. Return to the trigger step and copy the generated **HTTP POST URL** -- this is your webhook URL.
+
+### Verifying the Webhook
+
+You can verify the webhook is working with a minimal test before configuring the full integration:
+
+**macOS / Linux:**
+
+```bash
+curl -X POST "<your-webhook-url>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "message",
+    "attachments": [{
+      "contentType": "application/vnd.microsoft.card.adaptive",
+      "content": {
+        "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.4",
+        "body": [{
+          "type": "TextBlock",
+          "text": "Webhook is working!",
+          "weight": "Bolder",
+          "size": "Large"
+        }]
+      }
+    }]
+  }'
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$body = @{
+    type = "message"
+    attachments = @(@{
+        contentType = "application/vnd.microsoft.card.adaptive"
+        content = @{
+            type = "AdaptiveCard"
+            '$schema' = "http://adaptivecards.io/schemas/adaptive-card.json"
+            version = "1.4"
+            body = @(@{
+                type = "TextBlock"
+                text = "Webhook is working!"
+                weight = "Bolder"
+                size = "Large"
+            })
+        }
+    })
+} | ConvertTo-Json -Depth 10
+
+Invoke-RestMethod -Uri "<your-webhook-url>" -Method Post -ContentType "application/json" -Body $body
+```
+
+If the webhook is correctly configured, you should see a card with "Webhook is working!" appear in your Teams channel.
+
+---
+
+## 4. Setting the Environment Variable
+
+The webhook URL is stored in the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable. Set it persistently so it survives terminal restarts and system reboots.
+
+### macOS / Linux
+
+Add the export to your shell profile:
+
+```bash
+echo 'export AI_BRIEFING_TEAMS_WEBHOOK="https://prod-XX.westus.logic.azure.com:443/workflows/..."' >> ~/.zshrc
+```
+
+If you use bash instead of zsh, replace `~/.zshrc` with `~/.bash_profile`.
+
+Reload the profile:
+
+```bash
+source ~/.zshrc
+```
+
+**Verify:**
+
+```bash
+echo $AI_BRIEFING_TEAMS_WEBHOOK
+```
+
+### Windows
+
+Set a persistent user-level environment variable in PowerShell:
+
+```powershell
+[Environment]::SetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "https://prod-XX.westus.logic.azure.com:443/workflows/...", "User")
+```
+
+Close and reopen your terminal for the change to take effect.
+
+**Verify:**
+
+```powershell
+[Environment]::GetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "User")
+```
+
+> **Note:** Do not commit the webhook URL to version control. The `AI_BRIEFING_TEAMS_WEBHOOK` variable is read at runtime by the notification scripts and is never written to any tracked file.
+
+---
+
+## 5. How It Works
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant BS as Entry Script<br/>(briefing.sh / briefing.ps1)
+    participant NT as Notify Script<br/>(notify-teams.sh / notify-teams.ps1)
+    participant PY as build-teams-card.py
+    participant PA as Power Automate Webhook
+    participant TC as Teams Channel
+
+    BS->>BS: Briefing run completes successfully
+    BS->>NT: Call notify script with log file path
+
+    NT->>NT: Validate webhook URL is set
+    NT->>NT: Validate log file exists
+    NT->>PY: Invoke with log file path
+
+    PY->>PY: Parse log file for date, stories, topics, sections
+    PY->>PY: Extract bullet items and source links
+    PY->>PY: Build Adaptive Card JSON payload
+    PY-->>NT: Return JSON payload to stdout
+
+    NT->>PA: HTTP POST payload to webhook URL
+    PA->>TC: Deliver Adaptive Card to channel
+
+    Note over TC: Card appears with header,<br/>sections, bullets, links,<br/>and "Open in Notion" button
+```
+
+### Pipeline Overview
+
+```mermaid
+flowchart LR
+    A["logs/YYYY-MM-DD.log"] -->|Parsed by| B[build-teams-card.py]
+    B -->|Produces| C[Adaptive Card JSON]
+    C -->|POSTed by| D[notify-teams.sh / .ps1]
+    D -->|HTTP POST| E[Power Automate Webhook]
+    E -->|Delivers| F[Teams Channel Card]
+```
+
+### Step-by-Step
+
+1. **Trigger.** After a successful briefing run, the entry script (`briefing.sh` or `briefing.ps1`) calls the platform-native notify script.
+2. **Validation.** The notify script checks that the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set and that the log file for the current run exists. If either is missing, it exits silently (notifications are optional -- a missing webhook does not fail the run).
+3. **Log parsing.** The notify script invokes `scripts/build-teams-card.py`, passing the log file path as an argument. The Python script reads the log, extracts the briefing date, story count, topic count, section headers, bullet items, and source URLs.
+4. **Card building.** The Python script constructs a Microsoft Adaptive Card JSON payload following the schema described in [Section 7](#7-adaptive-card-format).
+5. **Delivery.** The notify script captures the JSON from stdout and POSTs it to the Power Automate webhook URL. Power Automate receives the payload and delivers the Adaptive Card to the configured Teams channel.
+
+---
+
+## 6. Testing
+
+You can test the Teams notification independently of a full briefing run by calling the notify scripts directly with explicit arguments.
+
+### macOS / Linux
+
+```bash
+./scripts/notify-teams.sh \
+  --webhook-url "https://prod-XX.westus.logic.azure.com:443/workflows/..." \
+  --log-file ./logs/2026-03-13.log
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\scripts\notify-teams.ps1 `
+  -WebhookUrl "https://prod-XX.westus.logic.azure.com:443/workflows/..." `
+  -LogFile .\logs\2026-03-13.log
+```
+
+### What to Expect
+
+- If the webhook URL and log file are valid, you should see a card appear in your Teams channel within a few seconds.
+- The script prints the HTTP response status code to stdout. A `200` or `202` indicates success.
+- If you do not have a log file from a real run, create a test log or use an existing one from the `logs/` directory.
+
+### Testing the Python Script Directly
+
+To inspect the generated JSON payload without actually sending it:
+
+```bash
+python3 scripts/build-teams-card.py ./logs/2026-03-13.log
+```
+
+This prints the full Adaptive Card JSON to stdout. You can pipe it to `jq` for pretty-printing:
+
+```bash
+python3 scripts/build-teams-card.py ./logs/2026-03-13.log | python3 -m json.tool
+```
+
+---
+
+## 7. Adaptive Card Format
+
+The Adaptive Card is built to provide a comprehensive at-a-glance summary of the daily briefing. It follows the [Microsoft Adaptive Card schema v1.4](https://adaptivecards.io/explorer/).
+
+### Card Structure
+
+```mermaid
+graph TD
+    A[Adaptive Card] --> B[Header Container]
+    A --> C[Section Containers]
+    A --> D[Action Set]
+
+    B --> B1["Accent-colored banner"]
+    B --> B2["Date: YYYY-MM-DD"]
+    B --> B3["Story count and topic count"]
+
+    C --> C1["Section 1: Header with emoji icon"]
+    C1 --> C1a["Bullet items"]
+    C1 --> C1b["Source links - clickable"]
+
+    C --> C2["Section 2: Header with emoji icon"]
+    C2 --> C2a["Bullet items"]
+    C2 --> C2b["Source links - clickable"]
+
+    C --> C3["... (up to 9 sections)"]
+
+    D --> D1["'Open Full Briefing in Notion' button"]
+```
+
+### Card Elements
+
+| Element | Description |
+|---|---|
+| **Full-width layout** | The card uses `"msteams": { "width": "Full" }` to span the entire width of the Teams message pane, maximizing readability |
+| **Accent header banner** | A `Container` with `"style": "accent"` background containing the briefing date, story count, and topic count in bold text |
+| **Section headers** | Each of the 9 topic sections gets a `TextBlock` header with an emoji icon prefix (e.g., "🤖 Claude Code / Anthropic", "🏛️ AI Policy & Regulation") |
+| **Bullet items** | Each news item within a section is rendered as a `TextBlock` with a bullet character prefix, using `"wrap": true` for proper text flow |
+| **Source links** | URLs extracted from the briefing are rendered as clickable inline links within the bullet text |
+| **Action button** | An `Action.OpenUrl` button labeled "Open Full Briefing in Notion" links directly to the Notion page URL extracted from the log |
+
+### Example Card Layout
+
+```
+┌──────────────────────────────────────────────────────┐
+│  ██████████████████████████████████████████████████  │
+│  📰 AI Daily Briefing — 2026-03-13                   │
+│  12 stories · 9 topics                               │
+│  ██████████████████████████████████████████████████  │
+│                                                      │
+│  🤖 Claude Code / Anthropic                          │
+│  • Claude Code ships multi-file editing in v2.8      │
+│  • Anthropic publishes new safety benchmarks         │
+│                                                      │
+│  🧠 OpenAI / Codex / ChatGPT                         │
+│  • OpenAI announces Codex integration with VS Code   │
+│  • ChatGPT adds real-time web browsing in free tier  │
+│                                                      │
+│  ... (remaining sections) ...                        │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐    │
+│  │       Open Full Briefing in Notion           │    │
+│  └──────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. Troubleshooting
+
+### HTTP 400 Bad Request
+
+**Cause:** The Adaptive Card JSON payload is malformed or does not conform to the schema expected by Power Automate.
+
+**Fix:**
+
+1. Run the Python script directly and inspect the output: `python3 scripts/build-teams-card.py ./logs/2026-03-13.log | python3 -m json.tool`
+2. Validate the output against the [Adaptive Card Designer](https://adaptivecards.io/designer/) by pasting the `content` object.
+3. Common causes: unescaped special characters in news text, missing required fields (`type`, `version`), or payload exceeding the 28 KB size limit for Teams cards.
+
+### HTTP 401 or 403
+
+**Cause:** The webhook URL is invalid, expired, or the Power Automate flow has been turned off.
+
+**Fix:**
+
+1. Verify the flow is still active in the Workflows app in Teams.
+2. If the flow was deleted or recreated, you will need to update `AI_BRIEFING_TEAMS_WEBHOOK` with the new URL.
+
+### "python3: command not found" / "'python3' is not recognized"
+
+**Cause:** Python 3 is not installed or not on the system PATH.
+
+**Fix:**
+
+- **macOS:** Install via `brew install python3` or download from [python.org](https://www.python.org/downloads/).
+- **Windows:** Install from [python.org](https://www.python.org/downloads/) or via `winget install Python.Python.3.12`. Ensure "Add Python to PATH" is checked during installation. The Windows notify script looks for `python` rather than `python3`.
+
+### Environment Variable Not Set
+
+**Symptom:** The notify script exits silently and no card appears in Teams. The briefing itself completes normally.
+
+**Fix:**
+
+1. Confirm the variable is set:
+   - macOS: `echo $AI_BRIEFING_TEAMS_WEBHOOK`
+   - Windows: `[Environment]::GetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "User")`
+2. If empty, follow the setup instructions in [Section 4](#4-setting-the-environment-variable).
+3. If you set it in the current session but the scheduled task does not pick it up, restart the terminal or (on Windows) log out and back in. Scheduled tasks inherit the environment at session start.
+
+### Power Automate Template Not Found
+
+**Symptom:** The "Post to a channel when a webhook request is received" template does not appear in the Workflows menu.
+
+**Fix:**
+
+1. Your Microsoft 365 plan may not include Power Automate, or your tenant admin may have restricted flow creation. Check with your IT admin.
+2. Use [Option B](#option-b-from-scratch-in-the-workflows-app) to create the flow manually from the Workflows app.
+3. If the Workflows app itself is not available, ask your admin to enable it or use the [Power Automate web portal](https://make.powerautomate.com/) to build the flow.
+
+### Card Appears But Is Empty or Truncated
+
+**Cause:** The log file does not contain a completed briefing, or the Python parser could not extract the expected sections.
+
+**Fix:**
+
+1. Confirm the log file contains a full briefing output: `grep -c "##" ./logs/2026-03-13.log` should return a count matching the number of topic sections.
+2. If the briefing run failed mid-way, the log will be incomplete. Re-run the briefing and the next notification will use the complete log.
+
+### Card Exceeds Size Limit
+
+**Cause:** Adaptive Cards in Teams have a ~28 KB payload limit. An unusually long briefing can exceed this.
+
+**Fix:** The `build-teams-card.py` script truncates content to stay within limits. If you see truncation warnings in the script output, the card will still be delivered but some trailing sections may be shortened. The "Open Full Briefing in Notion" button provides access to the complete content.
+
+---
+
+## 9. Files Involved
+
+| File | Platform | Purpose |
+|---|---|---|
+| `scripts/notify-teams.sh` | macOS / Linux | Shell wrapper -- validates inputs, calls `build-teams-card.py`, POSTs the result to the webhook |
+| `scripts/notify-teams.ps1` | Windows | PowerShell wrapper -- same logic as the shell variant using `Invoke-RestMethod` |
+| `scripts/build-teams-card.py` | Shared | Parses the log file, extracts briefing content, and builds the Adaptive Card JSON payload |
+| `briefing.sh` | macOS | Entry point that calls `notify-teams.sh` after a successful run |
+| `briefing.ps1` | Windows | Entry point that calls `notify-teams.ps1` after a successful run |
+
+### Integration Point
+
+The notification scripts are called at the end of the entry point scripts, after the Claude Code run completes and the log file is written. The call is conditional -- if `AI_BRIEFING_TEAMS_WEBHOOK` is not set, the notify script exits immediately with no error, making the entire Teams integration opt-in.
+
+```mermaid
+flowchart TD
+    A[briefing.sh / briefing.ps1] --> B{Briefing run succeeded?}
+    B -->|Yes| C{AI_BRIEFING_TEAMS_WEBHOOK set?}
+    B -->|No| D[Log failure and exit]
+    C -->|Yes| E[Call notify-teams.sh / .ps1]
+    C -->|No| F[Skip notification silently]
+    E --> G[build-teams-card.py parses log]
+    G --> H[POST Adaptive Card to webhook]
+    H --> I[Card delivered to Teams channel]
+    F --> J[Done]
+    I --> J
+    D --> J
+```
+
+---
+
+## Author
+
+**Son Nguyen** &mdash; [github.com/hoangsonww](https://github.com/hoangsonww) &middot; [sonnguyenhoang.com](https://sonnguyenhoang.com)

--- a/README.md
+++ b/README.md
@@ -9,18 +9,20 @@
 ![PowerShell](https://img.shields.io/badge/PowerShell-5.1+-5391FE?logo=make&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-launchd-000000?logo=apple&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-Task_Scheduler-0078D4?logo=task&logoColor=white)
+![Teams](https://img.shields.io/badge/Microsoft_Teams-Webhook-6264A7?logo=teams&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-Version_Control-F05032?logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-Automated daily AI news research agent that searches the web, compiles a structured briefing, and publishes it to Notion -- powered by Claude Code CLI. Supports both macOS (launchd) and Windows (Task Scheduler).
+Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams -- powered by Claude Code CLI. Supports both macOS (launchd) and Windows (Task Scheduler).
 
 ## Overview
 
-AI News Briefing is a fully automated pipeline that runs every morning on your machine. It uses Claude Code in headless mode to act as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), and writing the finished page directly to a Notion database.
+AI News Briefing is a fully automated pipeline that runs every morning on your machine. It uses Claude Code in headless mode to act as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), writing the finished page directly to a Notion database, and optionally posting a styled Adaptive Card summary to Microsoft Teams.
 
-The entire process -- from triggering to publishing -- requires zero human intervention. You wake up, open Notion, and your daily AI briefing is already there.
+The entire process -- from triggering to publishing -- requires zero human intervention. You wake up, open Notion (or Teams), and your daily AI briefing is already there.
 
 ### Why it exists
 
@@ -50,6 +52,13 @@ flowchart TD
     G -->|Step 3: Write| H[Notion MCP]
     H -->|Creates page| I[Notion Database]
 
+    B1 -->|If webhook set| T[notify-teams.sh]
+    B2 -->|If webhook set| T2[notify-teams.ps1]
+    T --> U[build-teams-card.py]
+    T2 --> U
+    U --> V[Teams Webhook]
+    V --> W[Teams Channel]
+
     B1 -->|Logs output| J[logs/YYYY-MM-DD.log]
     B2 -->|Logs output| J
     J -->|Auto-cleanup| K[Delete logs older than 30 days]
@@ -61,7 +70,8 @@ flowchart TD
 2. The script reads the prompt from `prompt.md` and passes it to the Claude Code CLI in print mode.
 3. Claude Code executes the prompt as an agentic task -- performing web searches, compiling results, and calling the Notion MCP tool.
 4. Notion receives the finished briefing as a new database page.
-5. Logs are written to a date-stamped file and automatically pruned after 30 days.
+5. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which invokes `build-teams-card.py` to post a styled Adaptive Card to the configured Teams channel.
+6. Logs are written to a date-stamped file and automatically pruned after 30 days.
 
 ## Prerequisites
 
@@ -71,6 +81,7 @@ flowchart TD
 | **Claude Code CLI** | Installed at `~/.local/bin/claude` with a valid Anthropic API key or Max subscription |
 | **Notion MCP** | The Notion MCP server must be configured in Claude Code's MCP settings with access to your workspace |
 | **WebSearch tool** | Available by default in Claude Code (no extra setup needed) |
+| **Python 3.x** | Required for Teams notification card builder (pre-installed on macOS, install from [python.org](https://www.python.org/downloads/) on Windows) |
 | **Make** (optional) | GNU Make for using the Makefile task runner (`winget install GnuWin32.Make` on Windows, pre-installed on macOS) |
 
 ## Installation
@@ -245,7 +256,7 @@ The project includes a cross-platform `Makefile` that auto-detects your OS and r
 
 ### Utility Scripts Reference
 
-The `scripts/` directory contains 12 utility script pairs (`.sh` for macOS/Linux, `.ps1` for Windows) for managing and troubleshooting the system.
+The `scripts/` directory contains 13 utility script pairs (`.sh` for macOS/Linux, `.ps1` for Windows) plus the `build-teams-card.py` helper for managing and troubleshooting the system.
 
 | Script | Description | Example Usage |
 |---|---|---|
@@ -260,6 +271,7 @@ The `scripts/` directory contains 12 utility script pairs (`.sh` for macOS/Linux
 | `topic-edit` | Add, remove, or list topics in prompt.md | `bash scripts/topic-edit.sh --add "AI Hardware" "GPU news"` |
 | `update-schedule` | Change daily run time | `bash scripts/update-schedule.sh --hour 7 --minute 30` |
 | `notify` | Send native OS notification for briefing status | `bash scripts/notify.sh` |
+| `notify-teams` | Post briefing summary to Microsoft Teams via webhook | `bash scripts/notify-teams.sh` |
 | `uninstall` | Remove scheduler; `--all` also removes logs and backups | `bash scripts/uninstall.sh --all` |
 
 **Windows equivalents** use the same names with `.ps1` extension and PowerShell parameter syntax (e.g., `.\scripts\health-check.ps1`, `.\scripts\topic-edit.ps1 -Action add -Name "AI Hardware" -Description "GPU news"`).
@@ -301,6 +313,47 @@ Each generated page contains:
 - **Divider**
 - **Full Briefing** -- 9 sections (one per topic), each with 3-8 detailed bullet points and source attribution
 - **Key Takeaways table** -- a summary table of major trends and signals
+
+## Teams Integration
+
+The pipeline can optionally post a styled [Adaptive Card](https://adaptivecards.io/) with the full briefing to a Microsoft Teams channel via an incoming webhook. The card includes the TL;DR bullets and topic sections formatted for quick scanning directly in Teams.
+
+### Quick setup
+
+1. Create an incoming webhook in your Teams channel (see [NOTIFY_TEAMS.md](NOTIFY_TEAMS.md) for the full walkthrough).
+2. Set the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable to the webhook URL.
+3. The next briefing run will automatically detect the variable and post to Teams.
+
+### Set the webhook URL persistently
+
+**macOS / Linux:**
+
+```bash
+# Add to ~/.zshrc (or ~/.bashrc)
+export AI_BRIEFING_TEAMS_WEBHOOK="<url>"
+```
+
+**Windows (PowerShell):**
+
+```powershell
+[Environment]::SetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "<url>", "User")
+```
+
+### Test the integration
+
+**macOS / Linux:**
+
+```bash
+bash scripts/notify-teams.sh
+```
+
+**Windows:**
+
+```powershell
+.\scripts\notify-teams.ps1
+```
+
+For detailed setup instructions, troubleshooting, and card customization, see [NOTIFY_TEAMS.md](NOTIFY_TEAMS.md).
 
 ## How the Prompt Works
 
@@ -440,6 +493,8 @@ ai-news-briefing/
 │   ├── topic-edit.sh/.ps1       # Add/remove/list topics
 │   ├── update-schedule.sh/.ps1  # Change daily run time
 │   ├── notify.sh/.ps1           # Send native OS notifications
+│   ├── notify-teams.sh/.ps1     # Post briefing to Microsoft Teams
+│   ├── build-teams-card.py      # Build Adaptive Card JSON for Teams
 │   └── uninstall.sh/.ps1        # Full cleanup and removal
 ├── briefing.sh                  # macOS entry point (bash)
 ├── briefing.ps1                 # Windows entry point (PowerShell)
@@ -450,6 +505,7 @@ ai-news-briefing/
 ├── backups/                     # Prompt backups (git-ignored)
 ├── .gitignore
 ├── ARCHITECTURE.md              # Detailed architecture documentation
+├── NOTIFY_TEAMS.md              # Teams integration setup guide
 └── README.md                    # This file
 ```
 

--- a/briefing.ps1
+++ b/briefing.ps1
@@ -39,6 +39,18 @@ try {
 
     if ($exitCode -eq 0) {
         Write-Log "Briefing complete. Check Notion for today's report."
+
+        # Post TL;DR to Teams channel if webhook is configured
+        $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
+        if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
+            Write-Log "Sending Teams notification..."
+            try {
+                & $teamsScript -LogFile $LogFile
+                Write-Log "Teams notification sent."
+            } catch {
+                Write-Log "Teams notification failed: $_"
+            }
+        }
     } else {
         Write-Log "Briefing FAILED with exit code $exitCode."
     }

--- a/briefing.sh
+++ b/briefing.sh
@@ -31,6 +31,17 @@ TIME=$(date +%H:%M:%S)
 
 if [ $EXIT_CODE -eq 0 ]; then
   echo "[$DATE $TIME] Briefing complete. Check Notion for today's report." >> "$LOG_FILE"
+
+  # Post TL;DR to Teams channel if webhook is configured
+  TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
+  if [[ -x "$TEAMS_SCRIPT" && -n "${AI_BRIEFING_TEAMS_WEBHOOK:-}" ]]; then
+    echo "[$DATE $(date +%H:%M:%S)] Sending Teams notification..." >> "$LOG_FILE"
+    if "$TEAMS_SCRIPT" --log-file "$LOG_FILE"; then
+      echo "[$DATE $(date +%H:%M:%S)] Teams notification sent." >> "$LOG_FILE"
+    else
+      echo "[$DATE $(date +%H:%M:%S)] Teams notification failed." >> "$LOG_FILE"
+    fi
+  fi
 else
   echo "[$DATE $TIME] Briefing FAILED with exit code $EXIT_CODE." >> "$LOG_FILE"
 fi

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       <li><a href="#topics">Topics</a></li>
       <li><a href="#quickstart">Quick Start</a></li>
       <li><a href="#makefile">Makefile</a></li>
+      <li><a href="#teams">Teams</a></li>
       <li><a href="#cost">Cost</a></li>
     </ul>
     <button class="nav-hamburger" aria-label="Toggle navigation">
@@ -75,7 +76,7 @@
   <h1>Your AI News.<br><span class="gradient">Automated. Daily.</span></h1>
   <p class="hero-sub">
     A headless Claude Code agent that searches the web across 9 AI topic areas,
-    compiles a two-tier briefing, and publishes it to your Notion workspace &mdash;
+    compiles a two-tier briefing, and publishes it to Notion and Microsoft Teams &mdash;
     every morning, zero intervention.
   </p>
   <div class="hero-actions">
@@ -138,13 +139,20 @@
       <h3>Budget Capped</h3>
       <p>Hard $2.00 cap per run. Typical cost: $0.70-1.40. Safety-first design prevents runaway API spend.</p>
     </div>
+    <div class="feature-card">
+      <div class="feature-icon blue">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+      </div>
+      <h3>Teams Delivery</h3>
+      <p>Automatically posts a styled Adaptive Card to Microsoft Teams with the full briefing, section icons, and clickable source links.</p>
+    </div>
   </div>
 </section>
 <section class="section" id="architecture">
   <div class="section-header">
     <div class="section-label">Architecture</div>
     <h2 class="section-title">How it works</h2>
-    <p class="section-desc">Five stages, fully automated, from scheduler trigger to Notion page.</p>
+    <p class="section-desc">Six stages, fully automated, from scheduler trigger to Notion page and Teams channel.</p>
   </div>
   <div class="arch-flow">
     <div class="arch-node">
@@ -176,6 +184,12 @@
       <div class="arch-node-label">Notion</div>
       <div class="arch-node-sub">MCP &rarr; Database page</div>
     </div>
+    <div class="arch-arrow">&rarr;</div>
+    <div class="arch-node">
+      <div class="arch-node-icon">&#128172;</div>
+      <div class="arch-node-label">Teams</div>
+      <div class="arch-node-sub">Adaptive Card webhook</div>
+    </div>
   </div>
   <div style="margin-top: 3.5rem;">
     <h3 style="text-align:center; color:#e4e4ef; font-size:1.15rem; font-weight:700; margin-bottom:1.5rem;">Data Flow Pipeline</h3>
@@ -206,6 +220,12 @@ flowchart TD
 
     B1 -->|Logs output| J[logs/YYYY-MM-DD.log]
     B2 -->|Logs output| J
+
+    B1 -->|If webhook set| T1[notify-teams.sh]
+    B2 -->|If webhook set| T2[notify-teams.ps1]
+    T1 & T2 --> PY[build-teams-card.py]
+    PY --> TW[Teams Webhook]
+    TW --> TC[Teams Channel]
       </pre>
     </div>
   </div>
@@ -220,6 +240,7 @@ sequenceDiagram
     participant NR as Notion (Read)
     participant W as WebSearch
     participant NW as Notion (Write)
+    participant TW as Teams Webhook
 
     Note over S: 08:00 AM or manual trigger
     S->>E: Execute entry script
@@ -244,6 +265,13 @@ sequenceDiagram
     NW-->>C: Page URL
     C-->>E: Done
     E->>E: Log result
+
+    opt Teams webhook configured
+        E->>E: notify-teams.sh / .ps1
+        E->>E: build-teams-card.py (parse log)
+        E->>TW: POST Adaptive Card to webhook
+        TW-->>E: 202 Accepted
+    end
       </pre>
     </div>
   </div>
@@ -287,6 +315,11 @@ flowchart TD
     <div>&nbsp;&nbsp;<span class="file">prompt.md</span> <span class="dim"># Agent instructions</span></div>
     <div>&nbsp;&nbsp;<span class="file">com.ainews.briefing.plist</span> <span class="dim"># macOS scheduler</span></div>
     <div>&nbsp;&nbsp;<span class="file">install-task.ps1</span> <span class="dim"># Windows scheduler</span></div>
+    <div>&nbsp;&nbsp;<span class="dir">scripts/</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">notify-teams.sh</span> <span class="new-badge">NEW</span> <span class="dim"># macOS/Linux Teams notifier</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">notify-teams.ps1</span> <span class="new-badge">NEW</span> <span class="dim"># Windows Teams notifier</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">build-teams-card.py</span> <span class="new-badge">NEW</span> <span class="dim"># Adaptive Card builder</span></div>
+    <div>&nbsp;&nbsp;<span class="file">NOTIFY_TEAMS.md</span> <span class="new-badge">NEW</span> <span class="dim"># Teams integration docs</span></div>
     <div>&nbsp;&nbsp;<span class="dir">logs/</span> <span class="dim"># Run output (git-ignored)</span></div>
     <div>&nbsp;&nbsp;<span class="dir">wiki/</span> <span class="dim"># Landing page assets</span></div>
     <div>&nbsp;&nbsp;<span class="file">index.html</span> <span class="dim"># This page</span></div>
@@ -441,6 +474,68 @@ flowchart TD
     </table>
   </div>
 </section>
+<section class="section" id="teams">
+  <div class="section-header">
+    <div class="section-label">Teams</div>
+    <h2 class="section-title">Delivered to your channel</h2>
+    <p class="section-desc">Full briefing as a styled Adaptive Card, posted automatically after each run.</p>
+  </div>
+  <div style="margin-top: 2rem;">
+    <h3 style="text-align:center; color:#e4e4ef; font-size:1.15rem; font-weight:700; margin-bottom:1.5rem;">Teams Notification Pipeline</h3>
+    <div class="mermaid-wrap">
+      <pre class="mermaid">
+flowchart LR
+    A[Briefing Log] --> B[build-teams-card.py]
+    B --> C[Adaptive Card JSON]
+    C --> D[Power Automate Webhook]
+    D --> E[Teams Channel]
+      </pre>
+    </div>
+  </div>
+  <div style="max-width: 720px; margin: 2.5rem auto 0;">
+    <h3 style="color:#e4e4ef; font-size:1.05rem; font-weight:700; margin-bottom:1rem;">Setup</h3>
+    <div class="code-section" style="margin-bottom: 1.5rem;">
+      <div class="code-header">
+        <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+        <span class="code-title">macOS / Linux</span>
+        <button class="code-copy">Copy</button>
+      </div>
+      <div class="code-body">
+<pre><span class="comment"># Add to ~/.zshrc or ~/.bashrc</span>
+<span class="cmd">export</span> AI_BRIEFING_TEAMS_WEBHOOK=<span class="string">"&lt;your-power-automate-webhook-url&gt;"</span>
+
+<span class="comment"># Test it</span>
+<span class="cmd">./scripts/notify-teams.sh</span> logs/$(date +%Y-%m-%d).log</pre>
+      </div>
+    </div>
+    <div class="code-section" style="margin-bottom: 1.5rem;">
+      <div class="code-header">
+        <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+        <span class="code-title">Windows (PowerShell)</span>
+        <button class="code-copy">Copy</button>
+      </div>
+      <div class="code-body">
+<pre><span class="comment"># Set persistent environment variable</span>
+[Environment]::SetEnvironmentVariable(<span class="string">"AI_BRIEFING_TEAMS_WEBHOOK"</span>, <span class="string">"&lt;your-url&gt;"</span>, <span class="string">"User"</span>)
+
+<span class="comment"># Test it</span>
+<span class="cmd">.\scripts\notify-teams.ps1</span> logs\$(Get-Date -Format yyyy-MM-dd).log</pre>
+      </div>
+    </div>
+    <h3 style="color:#e4e4ef; font-size:1.05rem; font-weight:700; margin-bottom:1rem;">Card Format</h3>
+    <div style="background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; color: var(--text-dim); font-size: 0.92rem; line-height: 1.8;">
+      <div style="color: var(--text-bright); font-weight: 700; font-size: 1rem; margin-bottom: 0.5rem;">AI News Briefing &mdash; 2026-03-13 &middot; 42 stories</div>
+      <div style="border-top: 1px solid var(--border); margin: 0.75rem 0;"></div>
+      <div><strong style="color: var(--text);">&#129302; Claude Code / Anthropic</strong></div>
+      <div style="padding-left: 1.5rem;">&bull; Claude 4 crosses 10M daily users &mdash; <span style="color: var(--accent);">source</span></div>
+      <div style="padding-left: 1.5rem;">&bull; Anthropic open-sources tool-use SDK &mdash; <span style="color: var(--accent);">source</span></div>
+      <div style="margin-top: 0.5rem;"><strong style="color: var(--text);">&#128640; AI Startups &amp; Funding</strong></div>
+      <div style="padding-left: 1.5rem;">&bull; Synthesia raises $200M Series D &mdash; <span style="color: var(--accent);">source</span></div>
+      <div style="border-top: 1px solid var(--border); margin: 0.75rem 0;"></div>
+      <div style="font-style: italic; color: var(--text-dim);">&hellip; all 9 sections with clickable source links</div>
+    </div>
+  </div>
+</section>
 <section class="section" id="cost">
   <div class="section-header">
     <div class="section-label">Cost</div>
@@ -454,7 +549,7 @@ flowchart TD
       <div class="sub">$0.70 &ndash; $1.40 typical</div>
     </div>
     <div class="cost-card">
-      <div class="label">Monthly (Daily)</div>
+      <div class="label">Monthly (Run Daily)</div>
       <div class="value orange">~$30</div>
       <div class="sub">$21 &ndash; $42 range</div>
     </div>
@@ -483,6 +578,7 @@ flowchart TD
       <a href="https://github.com/hoangsonww/AI-News-Briefing" target="_blank" rel="noopener">Repository</a>
       <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/README.md" target="_blank" rel="noopener">README</a>
       <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/ARCHITECTURE.md" target="_blank" rel="noopener">Architecture</a>
+      <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_TEAMS.md" target="_blank" rel="noopener">Teams Setup</a>
       <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
     </div>
   </div>

--- a/scripts/build-teams-card.py
+++ b/scripts/build-teams-card.py
@@ -1,0 +1,254 @@
+"""Build an Adaptive Card JSON payload from an AI briefing log file.
+
+Usage: python3 build-teams-card.py <log_file>
+Writes JSON to stdout (UTF-8).
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+
+
+ICON_MAP = {
+    "Claude": "\U0001F916",
+    "Anthropic": "\U0001F916",
+    "NVIDIA": "\U0001F4BB",
+    "GTC": "\U0001F4BB",
+    "Policy": "\u2696\uFE0F",
+    "Regulation": "\u2696\uFE0F",
+    "Industry": "\U0001F3ED",
+    "Open Source": "\U0001F513",
+    "Coding": "\U0001F4DD",
+    "IDE": "\U0001F4DD",
+    "Agentic": "\U0001F517",
+    "Startup": "\U0001F680",
+    "Funding": "\U0001F680",
+    "Dev Tool": "\U0001F527",
+    "Framework": "\U0001F527",
+    "OpenAI": "\u2728",
+    "ChatGPT": "\u2728",
+}
+
+
+def get_icon(header):
+    for key, icon in ICON_MAP.items():
+        if key.lower() in header.lower():
+            return icon
+    return "\u25AA"
+
+
+def parse_log(lines):
+    """Parse sections, bullets, and sources from the log."""
+    sections = []
+    sources = []
+    current = None
+
+    for line in lines:
+        t = line.strip()
+
+        # Skip timestamps, empty lines
+        if re.match(r"^\d{4}-\d{2}-\d{2}\s\d{2}:", t):
+            continue
+        if not t:
+            continue
+        # Story count metadata
+        if re.match(r"^\*\*\d+\s+sections", t):
+            continue
+
+        # Source link: - [title](url)
+        m = re.match(r"^-\s+\[(.+?)\]\((.+?)\)$", t)
+        if m:
+            sources.append({"title": m.group(1), "url": m.group(2)})
+            continue
+
+        # "Sources:" label
+        if t == "Sources:":
+            continue
+
+        # Notion creation line
+        if "notion.so" in t and "briefing created" in t.lower():
+            continue
+
+        # Section header: **1. Something** or **Something**
+        m = re.match(r"^\*\*\d*\.?\s*(.+?)\*\*$", t)
+        if m:
+            current = {"header": m.group(1).strip(". "), "bullets": []}
+            sections.append(current)
+            continue
+
+        # Bullet point
+        m = re.match(r"^-\s+(.+)", t)
+        if m and current is not None:
+            current["bullets"].append(m.group(1))
+
+    return sections, sources
+
+
+def build_card(sections, sources):
+    """Build the full Adaptive Card payload."""
+    now = datetime.now()
+    date_display = f"{now.strftime('%B')} {now.day}, {now.year}"
+
+    story_count = sum(len(s["bullets"]) for s in sections)
+    section_count = len(sections)
+
+    if not sections:
+        sections = [
+            {"header": "Status", "bullets": ["Briefing completed successfully."]}
+        ]
+        story_count = 0
+        section_count = 0
+
+    # --- Header banner ---
+    body = [
+        {
+            "type": "Container",
+            "style": "accent",
+            "bleed": True,
+            "spacing": "none",
+            "items": [
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "auto",
+                            "verticalContentAlignment": "center",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "\U0001F4F0",
+                                    "size": "extraLarge",
+                                }
+                            ],
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "verticalContentAlignment": "center",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "AI Daily Briefing",
+                                    "weight": "bolder",
+                                    "size": "extraLarge",
+                                    "color": "light",
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": f"{date_display}  \u00B7  {story_count} stories across {section_count} topics",
+                                    "size": "medium",
+                                    "color": "light",
+                                    "isSubtle": True,
+                                    "spacing": "none",
+                                },
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+    # --- Sections with bullets ---
+    for section in sections:
+        icon = get_icon(section["header"])
+
+        # Section header
+        body.append(
+            {
+                "type": "Container",
+                "separator": True,
+                "spacing": "large",
+                "items": [
+                    {
+                        "type": "TextBlock",
+                        "text": f"{icon}  **{section['header']}**",
+                        "weight": "bolder",
+                        "size": "large",
+                        "wrap": True,
+                    }
+                ],
+            }
+        )
+
+        # Bullets
+        for bullet in section["bullets"]:
+            body.append(
+                {
+                    "type": "TextBlock",
+                    "text": f"\u2022  {bullet}",
+                    "wrap": True,
+                    "spacing": "small",
+                    "size": "medium",
+                }
+            )
+
+    # --- Sources section ---
+    if sources:
+        source_lines = "  \n".join(
+            f"[{s['title']}]({s['url']})" for s in sources
+        )
+        body.append(
+            {
+                "type": "Container",
+                "separator": True,
+                "spacing": "large",
+                "items": [
+                    {
+                        "type": "TextBlock",
+                        "text": "\U0001F517  **Sources**",
+                        "weight": "bolder",
+                        "size": "medium",
+                        "wrap": True,
+                        "isSubtle": True,
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": source_lines,
+                        "wrap": True,
+                        "size": "small",
+                        "isSubtle": True,
+                        "spacing": "small",
+                    },
+                ],
+            }
+        )
+
+    # --- Card envelope ---
+    card = {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "msteams": {"width": "Full"},
+        "body": body,
+    }
+
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "contentUrl": None,
+                "content": card,
+            }
+        ],
+    }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 build-teams-card.py <log_file>", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as f:
+        lines = f.readlines()
+
+    sections, sources = parse_log(lines)
+    payload = build_card(sections, sources)
+    sys.stdout.buffer.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notify-teams.ps1
+++ b/scripts/notify-teams.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 5.1
+
+# notify-teams.ps1 — Post today's AI briefing to a Teams channel via webhook.
+# Usage:
+#   .\scripts\notify-teams.ps1                          # Auto-detect from today's log
+#   .\scripts\notify-teams.ps1 -WebhookUrl "https://..."  # Override webhook URL
+#   .\scripts\notify-teams.ps1 -LogFile "path\to.log"     # Use specific log file
+
+param(
+    [string]$WebhookUrl = $env:AI_BRIEFING_TEAMS_WEBHOOK,
+    [string]$LogFile = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+$Date = Get-Date -Format "yyyy-MM-dd"
+
+if (-not $LogFile) {
+    $LogFile = Join-Path (Join-Path $ScriptDir "logs") "$Date.log"
+}
+
+if (-not $WebhookUrl) {
+    Write-Error "No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK env var or pass -WebhookUrl."
+    exit 1
+}
+
+if (-not (Test-Path $LogFile)) {
+    Write-Error "Log file not found: $LogFile"
+    exit 1
+}
+
+$logContent = Get-Content $LogFile -Raw -Encoding utf8
+
+if ($logContent -notmatch "Briefing complete") {
+    Write-Host "Briefing did not complete successfully. Skipping Teams notification."
+    exit 0
+}
+
+# Use shared Python builder for the Adaptive Card JSON
+$builderScript = Join-Path (Join-Path $ScriptDir "scripts") "build-teams-card.py"
+if (-not (Test-Path $builderScript)) {
+    Write-Error "build-teams-card.py not found at $builderScript"
+    exit 1
+}
+
+# Build JSON via Python using Process API for clean stdout capture
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = "python3"
+$psi.Arguments = "`"$builderScript`" `"$LogFile`""
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+$psi.CreateNoWindow = $true
+
+$proc = [System.Diagnostics.Process]::Start($psi)
+$jsonPayload = $proc.StandardOutput.ReadToEnd()
+$stderrOutput = $proc.StandardError.ReadToEnd()
+$proc.WaitForExit()
+
+if ($proc.ExitCode -ne 0) {
+    Write-Error "Failed to build Teams card: $stderrOutput"
+    exit 1
+}
+
+$bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonPayload)
+
+try {
+    $response = Invoke-RestMethod -Uri $WebhookUrl -Method Post -Body $bytes -ContentType "application/json; charset=utf-8"
+    Write-Host "Teams notification sent successfully."
+} catch {
+    $status = $_.Exception.Response.StatusCode.value__
+    Write-Host "Teams notification failed (HTTP $status): $_"
+    exit 1
+}

--- a/scripts/notify-teams.sh
+++ b/scripts/notify-teams.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# notify-teams.sh — Post today's AI briefing TL;DR to a Teams channel via webhook.
+# Usage:
+#   ./scripts/notify-teams.sh                              # Auto-detect from today's log
+#   ./scripts/notify-teams.sh --webhook-url "https://..."  # Override webhook URL
+#   ./scripts/notify-teams.sh --log-file "path/to.log"     # Use specific log file
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DATE=$(date +%Y-%m-%d)
+
+WEBHOOK_URL="${AI_BRIEFING_TEAMS_WEBHOOK:-}"
+LOG_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --webhook-url) WEBHOOK_URL="$2"; shift 2 ;;
+    --log-file)    LOG_FILE="$2";    shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$LOG_FILE" ]]; then
+  LOG_FILE="$SCRIPT_DIR/logs/$DATE.log"
+fi
+
+if [[ -z "$WEBHOOK_URL" ]]; then
+  echo "Error: No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK env var or pass --webhook-url." >&2
+  exit 1
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "Error: Log file not found: $LOG_FILE" >&2
+  exit 1
+fi
+
+if ! grep -q "Briefing complete" "$LOG_FILE"; then
+  echo "Briefing did not complete successfully. Skipping Teams notification."
+  exit 0
+fi
+
+# Build the Adaptive Card JSON payload
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+python3 "$SCRIPT_DIR/scripts/build-teams-card.py" "$LOG_FILE" > "$TMPFILE"
+
+# POST to webhook using file input (avoids shell encoding issues)
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d @"$TMPFILE" \
+  "$WEBHOOK_URL")
+
+if [[ "$HTTP_CODE" =~ ^2 ]]; then
+  echo "Teams notification sent successfully."
+else
+  echo "Teams notification failed (HTTP $HTTP_CODE)." >&2
+  exit 1
+fi

--- a/wiki/style.css
+++ b/wiki/style.css
@@ -378,6 +378,7 @@ a:hover {
 .feature-icon.cyan   { background: rgba(6, 182, 212, 0.12); color: #22d3ee; }
 .feature-icon.rose   { background: rgba(244, 63, 94, 0.12); color: #fb7185; }
 .feature-icon.amber  { background: rgba(245, 158, 11, 0.12); color: #fbbf24; }
+.feature-icon.blue   { background: rgba(59, 130, 246, 0.12); color: #60a5fa; }
 
 .feature-card h3 {
   font-size: 1.15rem;


### PR DESCRIPTION
Post a styled Adaptive Card to a Teams channel after each successful briefing run. The card includes a full-width accent header, section icons, all bullet items, clickable source links, and story/topic counts.

- Add scripts/build-teams-card.py (shared card builder, both platforms)
- Add scripts/notify-teams.sh and notify-teams.ps1 (webhook POST)
- Wire Teams notification into briefing.sh and briefing.ps1
- Add NOTIFY_TEAMS.md with full setup guide
- Update README, ARCHITECTURE.md, and index.html with Teams docs

Delivery is opt-in via the AI_BRIEFING_TEAMS_WEBHOOK environment variable pointing to a Power Automate workflow webhook URL.