### PR TITLE
Improve Teams card styling, fix encoding, enforce 28KB size limit

### DIFF
--- a/briefing.ps1
+++ b/briefing.ps1
@@ -40,7 +40,7 @@ try {
     if ($exitCode -eq 0) {
         Write-Log "Briefing complete. Check Notion for today's report."
 
-        # Post TL;DR to Teams channel if webhook is configured
+        # Post summary to Teams channel if webhook is configured
         $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
         if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
             Write-Log "Sending Teams notification..."

--- a/briefing.sh
+++ b/briefing.sh
@@ -32,7 +32,7 @@ TIME=$(date +%H:%M:%S)
 if [ $EXIT_CODE -eq 0 ]; then
   echo "[$DATE $TIME] Briefing complete. Check Notion for today's report." >> "$LOG_FILE"
 
-  # Post TL;DR to Teams channel if webhook is configured
+  # Post summary to Teams channel if webhook is configured
   TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
   if [[ -x "$TEAMS_SCRIPT" && -n "${AI_BRIEFING_TEAMS_WEBHOOK:-}" ]]; then
     echo "[$DATE $(date +%H:%M:%S)] Sending Teams notification..." >> "$LOG_FILE"

--- a/prompt.md
+++ b/prompt.md
@@ -76,6 +76,24 @@ Use these EXACT parameters:
 - Use --- for dividers between TL;DR and full briefing
 - Use > for notable quotes
 
+## Step 4: Print Full Briefing to stdout (CRITICAL)
+
+**THIS STEP IS MANDATORY.** After writing to Notion, you MUST print the COMPLETE briefing to stdout. The Teams notification system parses your stdout to build the card — if you summarize or truncate, the Teams card will be incomplete.
+
+Output format:
+1. Print the Notion page URL on the first line: `Notion: <url>`
+2. Print the ENTIRE briefing content exactly as written to Notion:
+   - `## TL;DR` section with ALL bullets
+   - ALL 9 `## N. Section Name` sections with ALL bullets
+   - `## Sources` section with ALL source links
+3. Use the same Markdown formatting (##, -, **bold**, ---)
+
+**Rules:**
+- Do NOT summarize — print every single line
+- Do NOT truncate — if Notion has 80 bullets, stdout must have 80 bullets
+- Do NOT replace the briefing with a summary like "4 sections, 10 stories"
+- The stdout output must be a verbatim copy of the Notion page content
+
 ## Important Notes
 - Focus on NEWS from the past 24 hours only — not evergreen content, not older stories
 - Do NOT repeat stories already covered in the previous briefing (from Step 0)

--- a/scripts/build-teams-card.py
+++ b/scripts/build-teams-card.py
@@ -9,6 +9,7 @@ import re
 import sys
 from datetime import datetime
 
+MAX_CARD_BYTES = 26_000  # Teams limit is 28KB; leave headroom
 
 ICON_MAP = {
     "Claude": "\U0001F916",
@@ -30,6 +31,24 @@ ICON_MAP = {
     "ChatGPT": "\u2728",
 }
 
+# Common encoding artifacts from Windows cp1252 / Notion fetch
+ENCODING_FIXES = {
+    "\u0393\u00C7\u00F6": "\u2014",  # em dash
+    "\u0393\u00C7\u00F4": "\u2013",  # en dash
+    "\u0393\u00C7\u00D6": "\u2018",  # left single quote
+    "\u0393\u00C7\u00D8": "\u2019",  # right single quote
+    "\u0393\u00C7\u00EC": "\u201C",  # left double quote
+    "\u0393\u00C7\u00EE": "\u201D",  # right double quote
+    "\u251C\u00F9": "\u00D7",        # multiplication sign
+}
+
+
+def fix_encoding(text):
+    """Replace common encoding artifacts with correct Unicode characters."""
+    for bad, good in ENCODING_FIXES.items():
+        text = text.replace(bad, good)
+    return text
+
 
 def get_icon(header):
     for key, icon in ICON_MAP.items():
@@ -39,68 +58,138 @@ def get_icon(header):
 
 
 def parse_log(lines):
-    """Parse sections, bullets, and sources from the log."""
+    """Parse sections, bullets, and sources from the log.
+
+    Handles two content formats:
+    - Short stdout summary: **bold headers** + short bullets (old format)
+    - Full briefing output: ## headings + rich bullets with bold headlines (new format)
+    """
     sections = []
     sources = []
+    tldr_bullets = []
     current = None
+    in_sources = False
+    in_tldr = False
+    in_key_takeaways = False
+    notion_url = None
 
     for line in lines:
-        t = line.strip()
+        t = fix_encoding(line.strip())
 
-        # Skip timestamps, empty lines
+        # Skip timestamps and empty lines
         if re.match(r"^\d{4}-\d{2}-\d{2}\s\d{2}:", t):
             continue
         if not t:
             continue
-        # Story count metadata
+
+        # Extract Notion URL (Step 4 format: "Notion: <url>" or legacy)
+        m = re.search(r"https://www\.notion\.so/\S+", t)
+        if m and notion_url is None:
+            notion_url = m.group(0)
+
+        # Skip metadata / dividers
         if re.match(r"^\*\*\d+\s+sections", t):
+            continue
+        if t == "---":
+            in_tldr = False
+            continue
+
+        # Sources section toggle
+        if re.match(r"^#+\s*Sources?$", t, re.IGNORECASE) or t == "Sources:":
+            in_sources = True
+            in_tldr = False
+            in_key_takeaways = False
+            continue
+
+        # Key Takeaways — skip the table, it doesn't render in Adaptive Cards
+        if re.match(r"^#+\s*Key Takeaways", t, re.IGNORECASE):
+            in_key_takeaways = True
+            in_sources = False
+            in_tldr = False
+            continue
+        if in_key_takeaways:
             continue
 
         # Source link: - [title](url)
-        m = re.match(r"^-\s+\[(.+?)\]\((.+?)\)$", t)
+        if in_sources:
+            m = re.match(r"^-\s+\[(.+?)\]\((.+?)\)", t)
+            if m:
+                sources.append({"title": m.group(1), "url": m.group(2)})
+            continue
+
+        # ## TL;DR section header
+        if re.match(r"^#+\s*TL;DR", t, re.IGNORECASE):
+            in_tldr = True
+            in_sources = False
+            continue
+
+        # TL;DR bullets — collect separately, will become first section
+        if in_tldr:
+            m = re.match(r"^-\s+(.+)", t)
+            if m:
+                bullet = re.sub(r"\*\*(.+?)\*\*", r"\1", m.group(1))
+                tldr_bullets.append(bullet)
+            continue
+
+        # ## N. Section heading (full briefing format)
+        m = re.match(r"^#+\s+\d+\.\s+(.+)", t)
         if m:
-            sources.append({"title": m.group(1), "url": m.group(2)})
+            current = {"header": m.group(1).strip(), "bullets": []}
+            sections.append(current)
+            in_sources = False
+            in_tldr = False
             continue
 
-        # "Sources:" label
-        if t == "Sources:":
+        # ## Section heading without number
+        m = re.match(r"^#+\s+(.+)", t)
+        if m:
+            header = m.group(1).strip()
+            if re.search(r"sources?|key takeaways", header, re.IGNORECASE):
+                continue
+            current = {"header": header, "bullets": []}
+            sections.append(current)
+            in_sources = False
+            in_tldr = False
             continue
 
-        # Notion creation line
-        if "notion.so" in t and "briefing created" in t.lower():
-            continue
-
-        # Section header: **1. Something** or **Something**
+        # **Bold section header** (short stdout format)
         m = re.match(r"^\*\*\d*\.?\s*(.+?)\*\*$", t)
         if m:
-            current = {"header": m.group(1).strip(". "), "bullets": []}
-            sections.append(current)
+            header = m.group(1).strip(". ")
+            if not re.search(r"sections?|stories", header, re.IGNORECASE):
+                current = {"header": header, "bullets": []}
+                sections.append(current)
             continue
 
         # Bullet point
         m = re.match(r"^-\s+(.+)", t)
         if m and current is not None:
-            current["bullets"].append(m.group(1))
+            bullet = m.group(1)
+            bullet = re.sub(r"\*\*(.+?)\*\*\s*[—–-]\s*", r"\1 — ", bullet)
+            bullet = re.sub(r"\*\*(.+?)\*\*", r"\1", bullet)
+            current["bullets"].append(bullet)
 
-    return sections, sources
+    if tldr_bullets:
+        sections.insert(0, {"header": "TL;DR", "bullets": tldr_bullets})
+
+    return sections, sources, notion_url
 
 
-def build_card(sections, sources):
+def build_card(sections, sources, notion_url=None):
     """Build the full Adaptive Card payload."""
     now = datetime.now()
     date_display = f"{now.strftime('%B')} {now.day}, {now.year}"
 
-    story_count = sum(len(s["bullets"]) for s in sections)
-    section_count = len(sections)
+    topic_sections = [s for s in sections if s["header"].upper() != "TL;DR"]
+    story_count = sum(len(s["bullets"]) for s in topic_sections)
+    section_count = len(topic_sections)
 
     if not sections:
-        sections = [
-            {"header": "Status", "bullets": ["Briefing completed successfully."]}
-        ]
+        sections = [{"header": "Status", "bullets": ["Briefing completed successfully."]}]
         story_count = 0
         section_count = 0
 
-    # --- Header banner ---
+    # ── Header ─────────────────────────────────────────────────────────────────
     body = [
         {
             "type": "Container",
@@ -115,13 +204,7 @@ def build_card(sections, sources):
                             "type": "Column",
                             "width": "auto",
                             "verticalContentAlignment": "center",
-                            "items": [
-                                {
-                                    "type": "TextBlock",
-                                    "text": "\U0001F4F0",
-                                    "size": "extraLarge",
-                                }
-                            ],
+                            "items": [{"type": "TextBlock", "text": "\U0001F4F0", "size": "extraLarge"}],
                         },
                         {
                             "type": "Column",
@@ -137,7 +220,7 @@ def build_card(sections, sources):
                                 },
                                 {
                                     "type": "TextBlock",
-                                    "text": f"{date_display}  \u00B7  {story_count} stories across {section_count} topics",
+                                    "text": f"{date_display}  \u00B7  {story_count} stories  \u00B7  {section_count} topics",
                                     "size": "medium",
                                     "color": "light",
                                     "isSubtle": True,
@@ -151,20 +234,27 @@ def build_card(sections, sources):
         }
     ]
 
-    # --- Sections with bullets ---
+    # ── Sections ───────────────────────────────────────────────────────────────
     for section in sections:
-        icon = get_icon(section["header"])
+        is_tldr = section["header"].upper() == "TL;DR"
+        icon = "\U0001F4CB" if is_tldr else get_icon(section["header"])
+        count = len(section["bullets"])
 
-        # Section header
+        # Section header with inline story count
+        header_text = f"{icon}  **{section['header']}**"
+        if not is_tldr and count > 0:
+            header_text += f"  \u00B7  {count} {'story' if count == 1 else 'stories'}"
+
         body.append(
             {
                 "type": "Container",
                 "separator": True,
                 "spacing": "large",
+                "style": "emphasis" if is_tldr else "default",
                 "items": [
                     {
                         "type": "TextBlock",
-                        "text": f"{icon}  **{section['header']}**",
+                        "text": header_text,
                         "weight": "bolder",
                         "size": "large",
                         "wrap": True,
@@ -173,50 +263,46 @@ def build_card(sections, sources):
             }
         )
 
-        # Bullets
         for bullet in section["bullets"]:
-            body.append(
-                {
-                    "type": "TextBlock",
-                    "text": f"\u2022  {bullet}",
-                    "wrap": True,
-                    "spacing": "small",
-                    "size": "medium",
-                }
-            )
+            body.append({
+                "type": "TextBlock",
+                "text": f"\u2022  {bullet}",
+                "wrap": True,
+                "spacing": "small",
+                "size": "medium",
+            })
 
-    # --- Sources section ---
+    # ── Sources ────────────────────────────────────────────────────────────────
     if sources:
-        source_lines = "  \n".join(
-            f"[{s['title']}]({s['url']})" for s in sources
-        )
+        source_items = [
+            {
+                "type": "TextBlock",
+                "text": "\U0001F4DA  **Sources**",
+                "weight": "bolder",
+                "size": "medium",
+                "spacing": "none",
+            }
+        ]
+        for s in sources:
+            source_items.append({
+                "type": "TextBlock",
+                "text": f"\u2022  [{s['title']}]({s['url']})",
+                "wrap": True,
+                "size": "small",
+                "spacing": "small",
+            })
+
         body.append(
             {
                 "type": "Container",
                 "separator": True,
                 "spacing": "large",
-                "items": [
-                    {
-                        "type": "TextBlock",
-                        "text": "\U0001F517  **Sources**",
-                        "weight": "bolder",
-                        "size": "medium",
-                        "wrap": True,
-                        "isSubtle": True,
-                    },
-                    {
-                        "type": "TextBlock",
-                        "text": source_lines,
-                        "wrap": True,
-                        "size": "small",
-                        "isSubtle": True,
-                        "spacing": "small",
-                    },
-                ],
+                "style": "emphasis",
+                "items": source_items,
             }
         )
 
-    # --- Card envelope ---
+    # ── Card ───────────────────────────────────────────────────────────────────
     card = {
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
         "type": "AdaptiveCard",
@@ -225,7 +311,16 @@ def build_card(sections, sources):
         "body": body,
     }
 
-    return {
+    if notion_url:
+        card["actions"] = [
+            {
+                "type": "Action.OpenUrl",
+                "title": "\U0001F4D3  Open Full Briefing in Notion",
+                "url": notion_url,
+            }
+        ]
+
+    payload = {
         "type": "message",
         "attachments": [
             {
@@ -236,6 +331,27 @@ def build_card(sections, sources):
         ],
     }
 
+    # ── Size enforcement ───────────────────────────────────────────────────────
+    encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    if len(encoded) > MAX_CARD_BYTES:
+        # Trim bullet text progressively
+        for item in body:
+            if item.get("type") == "TextBlock" and item["text"].startswith("\u2022"):
+                t = item["text"]
+                if len(t) > 150:
+                    item["text"] = t[:147] + "..."
+        encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+    # Last resort: drop sources
+    if len(encoded) > MAX_CARD_BYTES and body:
+        last = body[-1]
+        if last.get("type") == "Container" and any(
+            "\U0001F517" in i.get("text", "") for i in last.get("items", [])
+        ):
+            body.pop()
+
+    return payload
+
 
 def main():
     if len(sys.argv) < 2:
@@ -245,8 +361,8 @@ def main():
     with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as f:
         lines = f.readlines()
 
-    sections, sources = parse_log(lines)
-    payload = build_card(sections, sources)
+    sections, sources, notion_url = parse_log(lines)
+    payload = build_card(sections, sources, notion_url)
     sys.stdout.buffer.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
 
 


### PR DESCRIPTION
- Restyle Adaptive Card: section headers show story counts, sources are individually bulleted with emphasis background, Notion action button
- Add encoding fix map for cp1252/UTF-8 artifacts (em dash, en dash, etc.)
- Enforce Teams 28KB payload limit with progressive bullet truncation
- Simplify briefing scripts: remove Notion fetch fallback, post summary card with "Open Full Briefing in Notion" link instead
- Strengthen prompt.md Step 4 for stdout completeness (best-effort)
- Consistent logic across Windows (PS1) and macOS (bash) pipelines