### PR TITLE
Refactor Teams Notification Process and Update Documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ The system is cross-platform, supporting macOS (launchd) and Windows (Task Sched
 
 ## 1. System Architecture Overview
 
-The system is composed of four primary layers: a platform-native scheduler, a scripted entry point, the Claude Code AI engine, and the Notion API as the output destination. The core logic (prompt, search, compilation, Notion write) is identical across platforms -- only the scheduling and scripting layers differ.
+The system is composed of four primary layers: a platform-native scheduler, a scripted entry point, the Claude Code AI engine, and the Notion API as the output destination. The core logic (prompt, search, compilation, Notion write, card generation) is identical across platforms -- only the scheduling and scripting layers differ.
 
 ```mermaid
 graph TD
@@ -58,14 +58,15 @@ graph TD
         D -->|WebSearch tool| E[Web Sources]
         D -->|Notion MCP tool| F[Notion API]
         F --> G[Notion Page - AI Daily Briefing]
+        D -->|Writes| CJ["logs/YYYY-MM-DD-card.json"]
     end
 
     subgraph "Post-Processing"
         B1 -->|On success| T1[notify-teams.sh]
         B2 -->|On success| T2[notify-teams.ps1]
-        T1 --> TC[build-teams-card.py]
-        T2 --> TC
-        TC -->|Adaptive Card JSON| TW[Teams Webhook]
+        T1 -->|Validates & POSTs| CJ
+        T2 -->|Validates & POSTs| CJ
+        CJ -->|Adaptive Card JSON| TW[Teams Webhook]
     end
 
     B1 -->|Writes logs| H[logs/ Directory]
@@ -115,8 +116,8 @@ sequenceDiagram
     participant W as WebSearch Tool
     participant N as Notion MCP Tool
     participant NP as Notion Page
+    participant CF as logs/YYYY-MM-DD-card.json
     participant T as notify-teams.sh / .ps1
-    participant P as build-teams-card.py
     participant TW as Teams Webhook
 
     Note over S: Automatic trigger at 08:00<br/>or manual trigger
@@ -140,13 +141,14 @@ sequenceDiagram
     N->>NP: Create page in AI Daily Briefing database
     N-->>C: Page URL returned
 
+    C->>CF: Write Adaptive Card JSON (Step 4)
+
     C-->>E: Output with page URL
     E->>E: Log success or failure
     E->>E: Check AI_BRIEFING_TEAMS_WEBHOOK
     E->>T: notify-teams.sh / .ps1
-    T->>P: build-teams-card.py (parse log)
-    P-->>T: Adaptive Card JSON
-    T->>TW: POST to Teams webhook
+    T->>CF: Read and validate card JSON
+    T->>TW: POST card JSON to Teams webhook
     TW-->>T: 200 OK
     E->>E: Clean up logs older than 30 days
 ```
@@ -239,15 +241,20 @@ graph TD
 
 A PowerShell script that registers (or re-registers) the Windows Task Scheduler task. Accepts `-Hour` and `-Minute` parameters for schedule customization. Removes any existing task with the same name before creating a new one, making it idempotent.
 
-### 3.4 AI Prompt (`prompt.md`)
+### 3.4 AI Prompt and Skill Definition
 
-The prompt is a structured Markdown document that serves as the complete instruction set for Claude Code. It is shared across both platforms with no platform-specific content.
+The AI's behavior is governed by two instruction files: `prompt.md` (the base prompt read by the entry scripts) and `~/.claude/commands/ai-news-briefing.md` (the Claude Code skill definition). Together they form the complete instruction set for a briefing run. Both are shared across platforms with no platform-specific content.
 
 ```mermaid
 graph TD
     A[prompt.md] --> B[Step 1: Search for News]
     A --> C[Step 2: Compile the Briefing]
     A --> D[Step 3: Write to Notion]
+
+    SK["~/.claude/commands/ai-news-briefing.md"] --> B
+    SK --> C
+    SK --> D
+    SK --> F[Step 4: Write Adaptive Card JSON]
 
     B --> B1[9 Topic Definitions]
     B --> B2[Search Strategy Templates]
@@ -259,15 +266,20 @@ graph TD
     D --> D1[Notion Page Parameters]
     D --> D2[Formatting Rules]
     D --> D3[Important Constraints]
+
+    F --> F1["logs/YYYY-MM-DD-card.json"]
+    F --> F2[Adaptive Card v1.4 Schema]
+    F --> F3["ASCII-safe, ≤26KB"]
 ```
 
-**How the prompt guides Claude:**
+**How the prompt and skill guide Claude:**
 
 1. **Topic enumeration.** The 9 topics are explicitly listed with examples of what to search for, removing ambiguity about scope.
 2. **Search strategy.** Template queries like `"[topic] news today [current date]"` guide Claude toward recent content rather than evergreen articles.
 3. **Two-tier output format.** The TL;DR tier provides a scannable summary; the full briefing tier provides depth. This separation is defined in the prompt, not in code.
 4. **Exact Notion API parameters.** The `parent` database ID, property schema, and formatting rules are hardcoded in the prompt so Claude produces the correct API call every time.
 5. **Guardrails.** Instructions like "Focus on NEWS from the past 24-48 hours only" and "If a topic has no significant news today, say 'No major updates today'" prevent hallucination and filler content.
+6. **Card generation (Step 4).** The skill definition includes the Adaptive Card JSON template and constraints (valid JSON, ASCII-safe text, ≤26KB). Claude writes the final card payload directly to `logs/YYYY-MM-DD-card.json`, eliminating any need for post-hoc log parsing.
 
 ### 3.5 Makefile (Cross-Platform Task Runner)
 
@@ -346,14 +358,14 @@ On Windows, the equivalent is `schtasks /run /tn AiNewsBriefing`, or simply `mak
 
 ### 3.9 Teams Notification Pipeline
 
-After a successful briefing run, the system can optionally post a summary to a Microsoft Teams channel via a Power Automate webhook. The notification pipeline uses a three-file architecture: a platform-native shell script dispatches to a shared Python builder, which produces an Adaptive Card JSON payload for the webhook.
+After a successful briefing run, the system can optionally post a summary to a Microsoft Teams channel via a Power Automate webhook. The pipeline has two stages: Claude Code writes the final Adaptive Card JSON directly during the briefing session (Step 4), then a thin shell script validates and POSTs the file to the webhook. There is no Python dependency and no log parsing.
 
 ```mermaid
 flowchart LR
-    L["logs/YYYY-MM-DD.log"] -->|Input| NS["notify-teams.sh / .ps1"]
-    NS -->|Invokes| PY["build-teams-card.py"]
-    PY -->|Parses sections, bullets, sources| AC["Adaptive Card JSON"]
-    AC -->|POST| WH["Teams Webhook URL"]
+    CC["Claude Code (Step 4)"] -->|Writes| CJ["logs/YYYY-MM-DD-card.json"]
+    CJ -->|Input| NS["notify-teams.sh / .ps1"]
+    NS -->|Validates JSON| NS
+    NS -->|"curl -d @file"| WH["Teams Webhook URL"]
     WH -->|200 OK| NS
 ```
 
@@ -361,17 +373,29 @@ flowchart LR
 
 | File | Language | Purpose |
 |---|---|---|
-| `scripts/notify-teams.sh` | Bash | macOS/Linux entry point. Validates log, checks webhook env var, calls Python builder, POSTs via `curl`. |
+| `~/.claude/commands/ai-news-briefing.md` | Markdown | Skill definition with the card JSON template and constraints (Step 4). |
+| `scripts/notify-teams.sh` | Bash | macOS/Linux entry point. Validates card JSON exists and is valid, POSTs via `curl`. No Python dependency. |
 | `scripts/notify-teams.ps1` | PowerShell | Windows entry point. Same logic as the Bash variant using `Invoke-RestMethod`. |
-| `scripts/build-teams-card.py` | Python 3 | Shared card builder. Parses the log file and emits an Adaptive Card JSON payload to stdout. |
+| `scripts/build-teams-card.py` | Python 3 | **Legacy.** Old log-parsing card builder. No longer referenced by any script. Kept in repo for historical reference. |
+
+#### How the Card Is Produced
+
+The AI writes the Adaptive Card JSON as Step 4 of the briefing skill (`~/.claude/commands/ai-news-briefing.md`). The skill prompt contains the exact card template and enforces these constraints:
+
+- Valid JSON, under 26KB
+- ASCII-safe text only (no em dashes, curly quotes, or emoji in bullet text)
+- One bullet per story, max ~120 characters
+- Follows the Adaptive Card v1.4 schema
+
+The resulting file (`logs/YYYY-MM-DD-card.json`) is the exact payload that the notify script POSTs to Teams. There is no intermediate transformation.
 
 #### Adaptive Card Structure
 
-The card is built as an [Adaptive Card v1.4](https://adaptivecards.io/) with the following layout:
+The card follows the [Adaptive Card v1.4](https://adaptivecards.io/) schema with the following layout:
 
-1. **Header banner.** An accent-styled container with a newspaper icon, the title "AI Daily Briefing", the date, and a story/topic count.
-2. **Section blocks.** Each briefing topic gets a separator, an icon (matched via `ICON_MAP` keyword lookup), a bold header, and its bullet points.
-3. **Sources.** If the log contains `[title](url)` links, they are collected into a collapsible sources section at the bottom.
+1. **Header banner.** An accent-styled container with the title "AI Daily Briefing", the date, and a story/topic count.
+2. **Section blocks.** Each briefing topic gets a separator, a bold header, and its bullet points.
+3. **Action button.** An "Open Full Briefing in Notion" link at the bottom of the card.
 4. **Full-width rendering.** The card sets `"msteams": {"width": "Full"}` to use the entire channel width instead of the narrow default.
 
 The card is wrapped in the Teams message envelope:
@@ -673,7 +697,7 @@ graph TD
     SC --> SC3["dry-run.sh/.ps1"]
     SC --> SC4["topic-edit.sh/.ps1"]
     SC --> SC5["notify-teams.sh/.ps1"]
-    SC --> SC6["build-teams-card.py"]
+    SC --> SC6["build-teams-card.py (legacy)"]
     SC --> SC7["+ 8 more pairs"]
     A --> B[briefing.sh]
     A --> B2[briefing.ps1]
@@ -687,6 +711,7 @@ graph TD
     A --> BK["backups/"]
 
     G --> G1["YYYY-MM-DD.log"]
+    G --> G4["YYYY-MM-DD-card.json"]
     G --> G2["launchd-stdout.log (macOS)"]
     G --> G3["launchd-stderr.log (macOS)"]
 
@@ -718,10 +743,11 @@ graph TD
 | `README.md` | Shared | User-facing documentation | Yes |
 | `scripts/notify-teams.sh` | macOS/Linux | Teams notification entry point (Bash) | Yes |
 | `scripts/notify-teams.ps1` | Windows | Teams notification entry point (PowerShell) | Yes |
-| `scripts/build-teams-card.py` | Shared | Adaptive Card JSON builder (Python 3) | Yes |
+| `scripts/build-teams-card.py` | Shared | **Legacy.** Old log-parsing card builder. No longer referenced. | Yes |
 | `scripts/*.sh` | macOS/Linux | Utility scripts (12 tools) | Yes |
 | `scripts/*.ps1` | Windows | Utility scripts (12 tools) | Yes |
 | `logs/*.log` | Shared | Daily run logs | No (gitignored) |
+| `logs/*-card.json` | Shared | Adaptive Card JSON written by Claude Code (Step 4). POSTed to Teams as-is. | No (gitignored) |
 | `backups/` | Shared | Timestamped prompt.md backups | No (gitignored) |
 | `~/.local/bin/ai-news` | macOS | Manual trigger CLI script | No (outside repo) |
 
@@ -729,8 +755,9 @@ graph TD
 
 1. **Created**: At the start of each run, the entry script creates (or appends to) `logs/YYYY-MM-DD.log`.
 2. **Appended**: Claude Code's full stdout and stderr are appended. Multiple runs on the same day share one log file.
-3. **Rotated**: At the end of each run, logs older than 30 days are deleted.
-4. **launchd logs** (macOS only): `launchd-stdout.log` and `launchd-stderr.log` capture output from launchd itself. These are not rotated automatically.
+3. **Card JSON**: Claude Code writes `logs/YYYY-MM-DD-card.json` as Step 4 of the briefing skill. This file is the exact Adaptive Card payload sent to Teams.
+4. **Rotated**: At the end of each run, logs older than 30 days are deleted.
+5. **launchd logs** (macOS only): `launchd-stdout.log` and `launchd-stderr.log` capture output from launchd itself. These are not rotated automatically.
 
 ---
 
@@ -772,7 +799,7 @@ No secrets are stored in any tracked file. Claude Code's API key and Notion inte
 
 ## 11. Teams Notification Pipeline
 
-See [Section 3.9](#39-teams-notification-pipeline) for full architectural details.
+See [Section 3.9](#39-teams-notification-pipeline) for full architectural details. See also `E2E_FLOW.md` for the step-by-step end-to-end walkthrough including failure modes.
 
 ---
 
@@ -790,7 +817,7 @@ Change `--model sonnet` in the entry script for your platform. Consider adjustin
 
 | Channel | Status | Implementation Approach |
 |---|---|---|
-| Microsoft Teams | **Implemented** | Power Automate webhook + Adaptive Card via `notify-teams.sh/.ps1` and `build-teams-card.py`. See [Section 3.9](#39-teams-notification-pipeline). |
+| Microsoft Teams | **Implemented** | Claude Code writes Adaptive Card JSON (Step 4), `notify-teams.sh/.ps1` validates and POSTs to Power Automate webhook. See [Section 3.9](#39-teams-notification-pipeline). |
 | macOS notification | Planned | `osascript -e 'display notification ...'` in `briefing.sh` |
 | Windows toast | Planned | `New-BurntToastNotification` or `[Windows.UI.Notifications]` in `briefing.ps1` |
 | Slack | Planned | Slack MCP tool call in `prompt.md` or webhook `curl`/`Invoke-RestMethod` in the entry script |

--- a/E2E_FLOW.md
+++ b/E2E_FLOW.md
@@ -1,0 +1,279 @@
+# End-to-End Flow: AI News Briefing Pipeline
+
+This document describes the real runtime flow of this repository as of March 17, 2026.
+It is based on the current implementation in:
+
+- `briefing.sh`
+- `briefing.ps1`
+- `prompt.md`
+- `scripts/notify-teams.sh`
+- `scripts/notify-teams.ps1`
+- `scripts/build-teams-card.py` (legacy reference)
+- `Makefile`
+
+---
+
+## 1. System Topology
+
+```mermaid
+flowchart TD
+    subgraph Triggers
+        A1[macOS launchd\ncom.ainews.briefing.plist]
+        A2[Windows Task Scheduler\nAiNewsBriefing]
+        A3[Manual: make run / run-bg / run-scheduled]
+        A4[Manual direct: briefing.sh or briefing.ps1]
+    end
+
+    A1 --> B1[briefing.sh]
+    A2 --> B2[briefing.ps1]
+    A3 --> B1
+    A3 --> B2
+    A4 --> B1
+    A4 --> B2
+
+    B1 --> C[prompt.md loaded into memory]
+    B2 --> C
+
+    C --> D[Claude Code CLI\n-p --model sonnet --max-budget-usd 2.00\n--dangerously-skip-permissions]
+
+    D --> E[WebSearch tool calls]
+    D --> F[Notion MCP calls]
+
+    F --> G[Notion page created\nDate + Status + Topics]
+
+    D --> H[logs/YYYY-MM-DD.log\nstdout + stderr appended]
+    D --> I[Expected Teams artifact\nlogs/YYYY-MM-DD-card.json]
+
+    B1 --> J{AI_BRIEFING_TEAMS_WEBHOOK set?}
+    B2 --> J
+
+    J -->|No| K[Skip Teams notify]
+    J -->|Yes| L[notify-teams.sh / notify-teams.ps1]
+
+    L --> M{card.json exists\nand valid JSON?}
+    M -->|No| N[Notify step fails\nrun still completed]
+    M -->|Yes| O[POST card JSON to Teams webhook]
+
+    O --> P[Teams channel card]
+
+    B1 --> Q[Delete *.log older than 30 days]
+    B2 --> Q
+```
+
+---
+
+## 2. Runtime Sequence (Successful Path)
+
+```mermaid
+sequenceDiagram
+    participant S as Scheduler/Manual Trigger
+    participant E as Entry Script
+    participant C as Claude CLI
+    participant W as WebSearch
+    participant N as Notion MCP
+    participant L as logs/YYYY-MM-DD.log
+    participant CF as logs/YYYY-MM-DD-card.json
+    participant T as notify-teams
+    participant TW as Teams Webhook
+
+    S->>E: Start briefing.sh or briefing.ps1
+    E->>E: Resolve dirs and date
+    E->>E: Clear CLAUDECODE env var
+    E->>E: Ensure logs/ exists
+    E->>E: Load prompt.md
+
+    E->>C: Run Claude with prompt text
+    C->>W: Search news by topic
+    W-->>C: Recent results
+    C->>N: Create Notion page
+    N-->>C: Notion URL / success
+
+    C-->>L: Append run output
+    C-->>CF: Write Adaptive Card JSON (expected)
+    E->>E: Record success in log
+
+    E->>T: Call notify-teams (if webhook env var set)
+    T->>CF: Read + validate JSON
+    T->>TW: POST payload as-is
+    TW-->>T: 2xx
+    T-->>E: success
+
+    E->>E: Cleanup logs older than 30 days
+```
+
+---
+
+## 3. Stage-by-Stage Contracts
+
+### Stage A: Trigger and Entry
+
+| Area | macOS path | Windows path |
+|---|---|---|
+| Scheduler | `com.ainews.briefing.plist` | Task `AiNewsBriefing` via `install-task.ps1` |
+| Entry script | `briefing.sh` | `briefing.ps1` |
+| Default schedule | 08:00 daily | 08:00 daily |
+| Manual trigger | `make run`, `make run-bg`, `make run-scheduled` | same Make targets, or `schtasks /run /tn AiNewsBriefing` |
+
+Entry scripts do the same core setup:
+
+1. Compute `DATE`, `LOG_DIR`, `LOG_FILE`.
+2. Clear `CLAUDECODE` to avoid nested-session failures.
+3. Create `logs/` if missing.
+4. Read `prompt.md` as one string.
+5. Invoke Claude CLI with model and budget cap.
+6. Append output to `logs/YYYY-MM-DD.log`.
+7. Attempt Teams notify only when webhook env var is present.
+8. Delete only old `*.log` files (>30 days).
+
+### Stage B: Date Override / Backfill Path
+
+Both entry scripts support backfill:
+
+- Bash: `briefing.sh YYYY-MM-DD`
+- PowerShell: `briefing.ps1 -BriefingDate YYYY-MM-DD`
+- Make wrapper: `make run D=YYYY-MM-DD`
+
+When date override is used, scripts prepend a runtime instruction block to the prompt:
+
+- Search relative to override date, not current day.
+- Use override date in Notion title.
+- Use override date in card filename (`logs/<date>-card.json`).
+
+### Stage C: AI Execution Logic
+
+`prompt.md` defines the internal flow:
+
+1. Step 0: fetch previous briefing from Notion for de-duplication.
+2. Step 1: search 9 topic areas for past-24-hour updates.
+3. Step 2: compile TLDR + full briefing sections with dates.
+4. Step 3: write a new Notion page with fixed parent `data_source_id` and properties.
+5. Step 4: currently instructs model to print structured stdout for parsing.
+
+### Stage D: Teams Delivery
+
+Current notifier scripts are intentionally thin:
+
+- Find card file (default `logs/<today>-card.json`, or passed `--card-file` / `-CardFile`).
+- Validate JSON (`python3 -m json.tool` on shell, `ConvertFrom-Json` on PowerShell).
+- POST payload directly to webhook.
+
+They do **not** build cards from logs.
+
+---
+
+## 4. Teams Notification Decision Graph
+
+```mermaid
+flowchart TD
+    A[Entry script success] --> B{AI_BRIEFING_TEAMS_WEBHOOK set?}
+    B -->|No| C[Skip Teams step]
+    B -->|Yes| D[Call notify-teams]
+
+    D --> E{Card file path\nexists?}
+    E -->|No| F[Fail: Card file not found]
+    E -->|Yes| G{JSON valid?}
+
+    G -->|No| H[Fail: Invalid JSON]
+    G -->|Yes| I[POST to webhook]
+
+    I --> J{HTTP 2xx?}
+    J -->|Yes| K[Teams notification sent]
+    J -->|No| L[Fail: webhook rejected]
+```
+
+---
+
+## 5. Current Divergence: Prompt vs Runtime Expectations
+
+There is a material mismatch in the repo right now:
+
+| Component | What it expects |
+|---|---|
+| `prompt.md` Step 4 | AI prints strict stdout format for a parser |
+| `scripts/notify-teams.sh/.ps1` | A prebuilt `logs/YYYY-MM-DD-card.json` exists |
+| `scripts/build-teams-card.py` | Parser exists but is legacy and not called by entry scripts |
+
+Practical impact:
+
+- If Claude follows `prompt.md` literally and does **not** write `-card.json`, Teams notify fails with `Card file not found`.
+- If a separate local skill or custom command makes Claude write `-card.json`, notify succeeds.
+
+This is the most important operational risk in the current E2E path.
+
+---
+
+## 6. Failure-State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Triggered
+    Triggered --> Setup
+    Setup --> ClaudeRun
+
+    ClaudeRun --> ClaudeFailed: non-zero exit / runtime error
+    ClaudeRun --> ClaudeSucceeded: exit 0
+
+    ClaudeSucceeded --> TeamsCheck
+    TeamsCheck --> CompleteNoTeams: webhook env not set
+    TeamsCheck --> NotifyAttempt: webhook env set
+
+    NotifyAttempt --> NotifyFailedMissingCard: card file absent
+    NotifyAttempt --> NotifyFailedInvalidJson: invalid JSON
+    NotifyAttempt --> NotifyFailedHttp: webhook non-2xx
+    NotifyAttempt --> CompleteWithTeams: notify success
+
+    ClaudeFailed --> Cleanup
+    CompleteNoTeams --> Cleanup
+    NotifyFailedMissingCard --> Cleanup
+    NotifyFailedInvalidJson --> Cleanup
+    NotifyFailedHttp --> Cleanup
+    CompleteWithTeams --> Cleanup
+
+    Cleanup --> [*]
+```
+
+Notes:
+
+- Teams notification failure does not currently mark the whole run as failed at the script level.
+- Log cleanup only targets `*.log`; old `*-card.json` files are not rotated by current scripts.
+
+---
+
+## 7. Artifacts and Ownership
+
+| Artifact | Producer | Consumer | Required for success |
+|---|---|---|---|
+| `logs/YYYY-MM-DD.log` | entry scripts + Claude stdout/stderr | humans, diagnostic scripts | No (diagnostic) |
+| Notion page | Claude via Notion MCP | Notion workspace | Yes |
+| `logs/YYYY-MM-DD-card.json` | Claude (expected) | notify-teams scripts | Yes for Teams path |
+| Teams message | notify-teams scripts | Teams channel | Optional |
+
+---
+
+## 8. Operational Checklist
+
+1. Ensure Claude CLI path exists (`~/.local/bin/claude` or `.exe`).
+2. Ensure Notion MCP is configured and has DB access.
+3. Ensure `prompt.md` and Teams pipeline are aligned on card generation strategy.
+4. If Teams is enabled, verify `AI_BRIEFING_TEAMS_WEBHOOK` and card file creation.
+5. Use `make tail` / `make log` to inspect run outcomes.
+
+---
+
+## 9. Suggested Alignment Work (High Priority)
+
+To eliminate ambiguity and make E2E deterministic, choose one canonical path:
+
+### Option A (recommended): Direct card JSON path
+
+- Update `prompt.md` Step 4 to require writing `logs/YYYY-MM-DD-card.json`.
+- Keep `notify-teams.sh/.ps1` as-is (thin validator/sender).
+- Keep `build-teams-card.py` as archival or remove it.
+
+### Option B: Parser path
+
+- Keep stdout-format Step 4 in prompt.
+- Reintroduce parser call (`build-teams-card.py`) in entry scripts before notify.
+- Notify scripts can continue posting file output from parser.
+
+Until one option is standardized end-to-end, Teams delivery remains environment-dependent.

--- a/Makefile
+++ b/Makefile
@@ -43,21 +43,21 @@ help: ## Show this help
 	@echo ""
 
 ## —— Run ——————————————————————————————————————————————
-run: check ## Run the briefing now (foreground, blocks until done)
+run: check ## Run the briefing now (foreground). Backfill: make run D=2026-03-15
 ifeq ($(PLATFORM),windows)
-	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1"
+	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D))
 else
-	@bash "$(SCRIPT_DIR)/briefing.sh"
+	@bash "$(SCRIPT_DIR)/briefing.sh" $(D)
 endif
 
-run-bg: check ## Run the briefing in background
+run-bg: check ## Run the briefing in background. Backfill: make run-bg D=2026-03-15
 ifeq ($(PLATFORM),windows)
-	@echo "[$(DATE)] Starting briefing in background..."
-	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" &
+	@echo "[$(or $(D),$(DATE))] Starting briefing in background..."
+	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D)) &
 	@echo "Running. Tail log with: make tail"
 else
-	@echo "[$(DATE)] Starting briefing in background..."
-	@nohup bash "$(SCRIPT_DIR)/briefing.sh" >/dev/null 2>&1 &
+	@echo "[$(or $(D),$(DATE))] Starting briefing in background..."
+	@nohup bash "$(SCRIPT_DIR)/briefing.sh" $(D) >/dev/null 2>&1 &
 	@echo "Running (PID $$!). Tail log with: make tail"
 endif
 

--- a/NOTIFY_TEAMS.md
+++ b/NOTIFY_TEAMS.md
@@ -26,7 +26,7 @@ This document describes the Microsoft Teams notification feature -- an optional 
 
 ## 1. Overview
 
-After a successful briefing run, the entry point scripts (`briefing.sh` on macOS, `briefing.ps1` on Windows) call a platform-native notification script (`notify-teams.sh` or `notify-teams.ps1`). Those scripts invoke a shared Python script (`scripts/build-teams-card.py`) that parses the run's log file, builds a Microsoft Adaptive Card JSON payload, and POSTs it to a Power Automate webhook URL.
+During the briefing run, the Claude Code AI agent writes a fully-formed Adaptive Card JSON file directly to `logs/YYYY-MM-DD-card.json`. After the run completes, the entry point scripts (`briefing.sh` on macOS, `briefing.ps1` on Windows) call a platform-native notification script (`notify-teams.sh` or `notify-teams.ps1`). Those scripts validate that the card file exists and contains valid JSON, then POST it as-is to a Power Automate webhook URL. No Python. No log parsing. No intermediate transformation.
 
 The result is a rich, interactive summary card delivered directly to your Teams channel -- giving the team immediate visibility into the daily briefing without opening Notion.
 
@@ -42,14 +42,14 @@ Not everyone on a team checks Notion first thing in the morning. Teams is where 
 |---|---|
 | **Microsoft Teams** | A Teams workspace where you have permission to add workflows to a channel |
 | **Power Automate** | Access to the Workflows app in Teams (included with most Microsoft 365 plans) |
-| **Python 3.8+** | Required to run `scripts/build-teams-card.py` -- must be accessible as `python3` (macOS/Linux) or `python` (Windows) |
 | **Webhook URL** | A Power Automate webhook URL for your target Teams channel (setup instructions below) |
-| **A completed briefing run** | The notification parses a log file, so at least one successful run must exist in `logs/` |
+| **A completed briefing run** | The notification reads a card JSON file, so at least one successful run must exist in `logs/` |
 
 ---
 
 ## 3. Setup: Creating the Webhook in Teams
 
+> [!IMPORTANT]
 > **Important:** The legacy "Incoming Webhook" connector in Teams is deprecated and will stop working. Use the Power Automate Workflows approach described below instead.
 
 There are two ways to create the webhook. Both produce the same result -- a URL that accepts HTTP POST requests and delivers an Adaptive Card to your channel.
@@ -181,6 +181,7 @@ Close and reopen your terminal for the change to take effect.
 [Environment]::GetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "User")
 ```
 
+> [!NOTE]
 > **Note:** Do not commit the webhook URL to version control. The `AI_BRIEFING_TEAMS_WEBHOOK` variable is read at runtime by the notification scripts and is never written to any tracked file.
 
 ---
@@ -192,24 +193,22 @@ Close and reopen your terminal for the change to take effect.
 ```mermaid
 sequenceDiagram
     participant BS as Entry Script<br/>(briefing.sh / briefing.ps1)
+    participant AI as Claude Code AI Agent
     participant NT as Notify Script<br/>(notify-teams.sh / notify-teams.ps1)
-    participant PY as build-teams-card.py
     participant PA as Power Automate Webhook
     participant TC as Teams Channel
 
-    BS->>BS: Briefing run completes successfully
-    BS->>NT: Call notify script with log file path
+    BS->>AI: Invoke Claude Code with prompt
+    AI->>AI: Search, deduplicate, create Notion page
+    AI->>AI: Write Adaptive Card JSON to logs/YYYY-MM-DD-card.json
+
+    AI-->>BS: Session completes
+    BS->>NT: Call notify script with card file path
 
     NT->>NT: Validate webhook URL is set
-    NT->>NT: Validate log file exists
-    NT->>PY: Invoke with log file path
-
-    PY->>PY: Parse log file for date, stories, topics, sections
-    PY->>PY: Extract bullet items and source links
-    PY->>PY: Build Adaptive Card JSON payload
-    PY-->>NT: Return JSON payload to stdout
-
-    NT->>PA: HTTP POST payload to webhook URL
+    NT->>NT: Validate card JSON file exists
+    NT->>NT: Validate file contains valid JSON
+    NT->>PA: HTTP POST card JSON to webhook URL
     PA->>TC: Deliver Adaptive Card to channel
 
     Note over TC: Card appears with header,<br/>sections, bullets, links,<br/>and "Open in Notion" button
@@ -219,20 +218,18 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    A["logs/YYYY-MM-DD.log"] -->|Parsed by| B[build-teams-card.py]
-    B -->|Produces| C[Adaptive Card JSON]
-    C -->|POSTed by| D[notify-teams.sh / .ps1]
-    D -->|HTTP POST| E[Power Automate Webhook]
-    E -->|Delivers| F[Teams Channel Card]
+    A["Claude Code AI Agent"] -->|Writes| B["logs/YYYY-MM-DD-card.json"]
+    B -->|Validated by| C[notify-teams.sh / .ps1]
+    C -->|HTTP POST| D[Power Automate Webhook]
+    D -->|Delivers| E[Teams Channel Card]
 ```
 
 ### Step-by-Step
 
-1. **Trigger.** After a successful briefing run, the entry script (`briefing.sh` or `briefing.ps1`) calls the platform-native notify script.
-2. **Validation.** The notify script checks that the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set and that the log file for the current run exists. If either is missing, it exits silently (notifications are optional -- a missing webhook does not fail the run).
-3. **Log parsing.** The notify script invokes `scripts/build-teams-card.py`, passing the log file path as an argument. The Python script reads the log, extracts the briefing date, story count, topic count, section headers, bullet items, and source URLs.
-4. **Card building.** The Python script constructs a Microsoft Adaptive Card JSON payload following the schema described in [Section 7](#7-adaptive-card-format).
-5. **Delivery.** The notify script captures the JSON from stdout and POSTs it to the Power Automate webhook URL. Power Automate receives the payload and delivers the Adaptive Card to the configured Teams channel.
+1. **Card generation.** During the briefing run, the Claude Code AI agent writes the final Adaptive Card JSON directly to `logs/YYYY-MM-DD-card.json` as the last step of its session. This is the exact payload that Teams will receive -- no intermediate format, no transformation.
+2. **Trigger.** After the Claude Code session completes, the entry script (`briefing.sh` or `briefing.ps1`) calls the platform-native notify script.
+3. **Validation.** The notify script checks that the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set and that the card JSON file for the current run exists. If either is missing, it exits silently (notifications are optional -- a missing webhook does not fail the run). It then validates that the file contains well-formed JSON.
+4. **Delivery.** The notify script POSTs the card JSON file as-is to the Power Automate webhook URL using `curl` (macOS/Linux) or `Invoke-RestMethod` (Windows). Power Automate receives the payload and delivers the Adaptive Card to the configured Teams channel.
 
 ---
 
@@ -245,7 +242,7 @@ You can test the Teams notification independently of a full briefing run by call
 ```bash
 ./scripts/notify-teams.sh \
   --webhook-url "https://prod-XX.westus.logic.azure.com:443/workflows/..." \
-  --log-file ./logs/2026-03-13.log
+  --card-file ./logs/2026-03-13-card.json
 ```
 
 ### Windows (PowerShell)
@@ -253,34 +250,31 @@ You can test the Teams notification independently of a full briefing run by call
 ```powershell
 .\scripts\notify-teams.ps1 `
   -WebhookUrl "https://prod-XX.westus.logic.azure.com:443/workflows/..." `
-  -LogFile .\logs\2026-03-13.log
+  -CardFile .\logs\2026-03-13-card.json
 ```
 
 ### What to Expect
 
-- If the webhook URL and log file are valid, you should see a card appear in your Teams channel within a few seconds.
+- If the webhook URL and card file are valid, you should see a card appear in your Teams channel within a few seconds.
 - The script prints the HTTP response status code to stdout. A `200` or `202` indicates success.
-- If you do not have a log file from a real run, create a test log or use an existing one from the `logs/` directory.
+- If you do not have a card file from a real run, you can craft a test card JSON following the format in [Section 7](#7-adaptive-card-format) or use an existing one from the `logs/` directory.
 
-### Testing the Python Script Directly
+### Inspecting a Card File
 
-To inspect the generated JSON payload without actually sending it:
-
-```bash
-python3 scripts/build-teams-card.py ./logs/2026-03-13.log
-```
-
-This prints the full Adaptive Card JSON to stdout. You can pipe it to `jq` for pretty-printing:
+> [!NOTE]
+> To verify a card file is valid JSON before sending:
 
 ```bash
-python3 scripts/build-teams-card.py ./logs/2026-03-13.log | python3 -m json.tool
+python3 -m json.tool ./logs/2026-03-13-card.json
 ```
+
+You can also paste the `content` object (inside `attachments[0].content`) into the [Adaptive Card Designer](https://adaptivecards.io/designer/) to preview how it will render in Teams.
 
 ---
 
 ## 7. Adaptive Card Format
 
-The Adaptive Card is built to provide a comprehensive at-a-glance summary of the daily briefing. It follows the [Microsoft Adaptive Card schema v1.4](https://adaptivecards.io/explorer/).
+The Adaptive Card is generated directly by the Claude Code AI agent during the briefing run and written to `logs/YYYY-MM-DD-card.json`. There is no separate parser or builder -- the AI writes the final JSON payload following the [Microsoft Adaptive Card schema v1.4](https://adaptivecards.io/explorer/). The skill prompt enforces the structure, size limits, and encoding rules described below.
 
 ### Card Structure
 
@@ -353,8 +347,8 @@ graph TD
 
 **Fix:**
 
-1. Run the Python script directly and inspect the output: `python3 scripts/build-teams-card.py ./logs/2026-03-13.log | python3 -m json.tool`
-2. Validate the output against the [Adaptive Card Designer](https://adaptivecards.io/designer/) by pasting the `content` object.
+1. Inspect the card file: `python3 -m json.tool ./logs/2026-03-13-card.json`
+2. Validate the output against the [Adaptive Card Designer](https://adaptivecards.io/designer/) by pasting the `attachments[0].content` object.
 3. Common causes: unescaped special characters in news text, missing required fields (`type`, `version`), or payload exceeding the 28 KB size limit for Teams cards.
 
 ### HTTP 401 or 403
@@ -366,14 +360,29 @@ graph TD
 1. Verify the flow is still active in the Workflows app in Teams.
 2. If the flow was deleted or recreated, you will need to update `AI_BRIEFING_TEAMS_WEBHOOK` with the new URL.
 
-### "python3: command not found" / "'python3' is not recognized"
+### Card File Not Found
 
-**Cause:** Python 3 is not installed or not on the system PATH.
+**Symptom:** The notify script exits with "Card file not found" and no card appears in Teams.
+
+**Cause:** The Claude Code AI agent did not write the card JSON file during the briefing run. This can happen if the session ended early, hit a budget limit, or the skill prompt's Step 4 was not reached.
 
 **Fix:**
 
-- **macOS:** Install via `brew install python3` or download from [python.org](https://www.python.org/downloads/).
-- **Windows:** Install from [python.org](https://www.python.org/downloads/) or via `winget install Python.Python.3.12`. Ensure "Add Python to PATH" is checked during installation. The Windows notify script looks for `python` rather than `python3`.
+1. Check the log file (`logs/YYYY-MM-DD.log`) to see how far the AI session progressed.
+2. Re-run the briefing. The skill prompt explicitly requires Step 4 (Write Teams Card JSON).
+3. If the problem persists, verify the skill prompt in `~/.claude/commands/ai-news-briefing.md` still includes the card-writing step.
+
+### Card File Is Not Valid JSON
+
+**Symptom:** The notify script exits with "not valid JSON" and no card appears in Teams.
+
+**Cause:** The AI wrote malformed JSON to the card file. This is rare but can happen if the session was interrupted or the AI produced truncated output.
+
+**Fix:**
+
+1. Inspect the file: `python3 -m json.tool ./logs/YYYY-MM-DD-card.json` -- the error message will indicate where the JSON is malformed.
+2. If the fix is minor (e.g., a trailing comma or missing brace), edit the file and re-run the notify script directly.
+3. If the file is severely malformed, delete it and re-run the briefing.
 
 ### Environment Variable Not Set
 
@@ -399,18 +408,19 @@ graph TD
 
 ### Card Appears But Is Empty or Truncated
 
-**Cause:** The log file does not contain a completed briefing, or the Python parser could not extract the expected sections.
+**Cause:** The AI wrote a structurally valid card but with incomplete content. This can happen if the briefing run hit a budget limit mid-way through card generation or if it was a slow news day with very few stories.
 
 **Fix:**
 
-1. Confirm the log file contains a full briefing output: `grep -c "##" ./logs/2026-03-13.log` should return a count matching the number of topic sections.
-2. If the briefing run failed mid-way, the log will be incomplete. Re-run the briefing and the next notification will use the complete log.
+1. Inspect the card file: `python3 -m json.tool ./logs/YYYY-MM-DD-card.json` and check if it contains the expected sections and bullets.
+2. If the card is truncated, re-run the briefing. The AI will generate a fresh card from the new run.
+3. The "Open Full Briefing in Notion" button provides access to the complete content even if the card itself is abbreviated.
 
 ### Card Exceeds Size Limit
 
 **Cause:** Adaptive Cards in Teams have a ~28 KB payload limit. An unusually long briefing can exceed this.
 
-**Fix:** The `build-teams-card.py` script truncates content to stay within limits. If you see truncation warnings in the script output, the card will still be delivered but some trailing sections may be shortened. The "Open Full Briefing in Notion" button provides access to the complete content.
+**Fix:** The AI skill prompt enforces a 26 KB limit on the card JSON. If the card still exceeds the limit, trim bullet text in the card file and re-run the notify script. The "Open Full Briefing in Notion" button provides access to the complete content.
 
 ---
 
@@ -418,9 +428,10 @@ graph TD
 
 | File | Platform | Purpose |
 |---|---|---|
-| `scripts/notify-teams.sh` | macOS / Linux | Shell wrapper -- validates inputs, calls `build-teams-card.py`, POSTs the result to the webhook |
+| `scripts/notify-teams.sh` | macOS / Linux | Shell wrapper -- validates card JSON file, POSTs it to the webhook |
 | `scripts/notify-teams.ps1` | Windows | PowerShell wrapper -- same logic as the shell variant using `Invoke-RestMethod` |
-| `scripts/build-teams-card.py` | Shared | Parses the log file, extracts briefing content, and builds the Adaptive Card JSON payload |
+| `scripts/build-teams-card.py` | Shared | **Legacy.** Old log parser that extracted briefing content from log files. Kept in repo but no longer referenced by any active script |
+| `logs/YYYY-MM-DD-card.json` | Shared | Adaptive Card JSON payload written directly by the Claude Code AI agent during the briefing run. This is the file that gets POSTed to Teams |
 | `briefing.sh` | macOS | Entry point that calls `notify-teams.sh` after a successful run |
 | `briefing.ps1` | Windows | Entry point that calls `notify-teams.ps1` after a successful run |
 
@@ -435,12 +446,14 @@ flowchart TD
     B -->|No| D[Log failure and exit]
     C -->|Yes| E[Call notify-teams.sh / .ps1]
     C -->|No| F[Skip notification silently]
-    E --> G[build-teams-card.py parses log]
-    G --> H[POST Adaptive Card to webhook]
-    H --> I[Card delivered to Teams channel]
-    F --> J[Done]
-    I --> J
-    D --> J
+    E --> G{card.json exists and valid?}
+    G -->|Yes| H[POST card JSON to webhook]
+    G -->|No| I[Log error and exit]
+    H --> J[Card delivered to Teams channel]
+    F --> K[Done]
+    J --> K
+    D --> K
+    I --> K
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams -- powered by Claude Code CLI. Supports both macOS (launchd) and Windows (Task Scheduler).
+Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams -- powered by Claude Code CLI. Supports both macOS (launchd) and Windows (Task Scheduler). Fully automated pipeline with zero manual intervention required after setup.
 
 ## Overview
 
@@ -52,11 +52,12 @@ flowchart TD
     G -->|Step 3: Write| H[Notion MCP]
     H -->|Creates page| I[Notion Database]
 
+    D -->|Step 4: Write card| J2[logs/YYYY-MM-DD-card.json]
+
     B1 -->|If webhook set| T[notify-teams.sh]
     B2 -->|If webhook set| T2[notify-teams.ps1]
-    T --> U[build-teams-card.py]
-    T2 --> U
-    U --> V[Teams Webhook]
+    T -->|POST card.json| V[Teams Webhook]
+    T2 -->|POST card.json| V
     V --> W[Teams Channel]
 
     B1 -->|Logs output| J[logs/YYYY-MM-DD.log]
@@ -70,7 +71,7 @@ flowchart TD
 2. The script reads the prompt from `prompt.md` and passes it to the Claude Code CLI in print mode.
 3. Claude Code executes the prompt as an agentic task -- performing web searches, compiling results, and calling the Notion MCP tool.
 4. Notion receives the finished briefing as a new database page.
-5. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which invokes `build-teams-card.py` to post a styled Adaptive Card to the configured Teams channel.
+5. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which validates and POSTs the pre-built `logs/YYYY-MM-DD-card.json` file (written by Claude in Step 4) to the configured Teams webhook.
 6. Logs are written to a date-stamped file and automatically pruned after 30 days.
 
 ## Prerequisites
@@ -81,7 +82,7 @@ flowchart TD
 | **Claude Code CLI** | Installed at `~/.local/bin/claude` with a valid Anthropic API key or Max subscription |
 | **Notion MCP** | The Notion MCP server must be configured in Claude Code's MCP settings with access to your workspace |
 | **WebSearch tool** | Available by default in Claude Code (no extra setup needed) |
-| **Python 3.x** | Required for Teams notification card builder (pre-installed on macOS, install from [python.org](https://www.python.org/downloads/) on Windows) |
+| **Python 3.x** | Optional (legacy card builder only, not used in current flow) |
 | **Make** (optional) | GNU Make for using the Makefile task runner (`winget install GnuWin32.Make` on Windows, pre-installed on macOS) |
 
 ## Installation
@@ -256,7 +257,7 @@ The project includes a cross-platform `Makefile` that auto-detects your OS and r
 
 ### Utility Scripts Reference
 
-The `scripts/` directory contains 13 utility script pairs (`.sh` for macOS/Linux, `.ps1` for Windows) plus the `build-teams-card.py` helper for managing and troubleshooting the system.
+The `scripts/` directory contains 13 utility script pairs (`.sh` for macOS/Linux, `.ps1` for Windows) for managing and troubleshooting the system.
 
 | Script | Description | Example Usage |
 |---|---|---|
@@ -271,7 +272,7 @@ The `scripts/` directory contains 13 utility script pairs (`.sh` for macOS/Linux
 | `topic-edit` | Add, remove, or list topics in prompt.md | `bash scripts/topic-edit.sh --add "AI Hardware" "GPU news"` |
 | `update-schedule` | Change daily run time | `bash scripts/update-schedule.sh --hour 7 --minute 30` |
 | `notify` | Send native OS notification for briefing status | `bash scripts/notify.sh` |
-| `notify-teams` | Post briefing summary to Microsoft Teams via webhook | `bash scripts/notify-teams.sh` |
+| `notify-teams` | Validate and POST pre-built `card.json` to Microsoft Teams webhook | `bash scripts/notify-teams.sh` |
 | `uninstall` | Remove scheduler; `--all` also removes logs and backups | `bash scripts/uninstall.sh --all` |
 
 **Windows equivalents** use the same names with `.ps1` extension and PowerShell parameter syntax (e.g., `.\scripts\health-check.ps1`, `.\scripts\topic-edit.ps1 -Action add -Name "AI Hardware" -Description "GPU news"`).
@@ -316,7 +317,7 @@ Each generated page contains:
 
 ## Teams Integration
 
-The pipeline can optionally post a styled [Adaptive Card](https://adaptivecards.io/) with the full briefing to a Microsoft Teams channel via an incoming webhook. The card includes the TL;DR bullets and topic sections formatted for quick scanning directly in Teams.
+The pipeline can optionally post a styled [Adaptive Card](https://adaptivecards.io/) with the full briefing to a Microsoft Teams channel via an incoming webhook. The AI generates the Adaptive Card JSON directly during the briefing run (Step 4), writing it to `logs/YYYY-MM-DD-card.json`. The notify script validates the JSON and POSTs it to the webhook as-is -- no intermediate parsing or transformation. See [E2E_FLOW.md](E2E_FLOW.md) for the full technical walkthrough.
 
 ### Quick setup
 
@@ -357,7 +358,7 @@ For detailed setup instructions, troubleshooting, and card customization, see [N
 
 ## How the Prompt Works
 
-The prompt (`prompt.md`) instructs Claude to execute three sequential steps within a single agentic session:
+The prompt (`prompt.md`) instructs Claude to execute four sequential steps within a single agentic session:
 
 ### Step 1: Search for News
 
@@ -373,6 +374,10 @@ Search results are synthesized into a two-tier format:
 ### Step 3: Write to Notion
 
 Claude calls the `mcp__notion__notion-create-pages` tool to create a new page in the target database with the compiled briefing as Notion-flavored Markdown content.
+
+### Step 4: Generate Teams Card JSON
+
+Claude writes a complete Adaptive Card JSON payload to `logs/YYYY-MM-DD-card.json`. This is the exact file that gets POSTed to the Teams webhook -- no parser or transformation sits between the AI output and Teams. The card includes a styled header, TL;DR bullets, topic sections, and an action button linking to the full Notion page.
 
 ## Topic Coverage
 
@@ -494,7 +499,7 @@ ai-news-briefing/
 │   ├── update-schedule.sh/.ps1  # Change daily run time
 │   ├── notify.sh/.ps1           # Send native OS notifications
 │   ├── notify-teams.sh/.ps1     # Post briefing to Microsoft Teams
-│   ├── build-teams-card.py      # Build Adaptive Card JSON for Teams
+│   ├── build-teams-card.py      # Legacy card builder (not used in current flow)
 │   └── uninstall.sh/.ps1        # Full cleanup and removal
 ├── briefing.sh                  # macOS entry point (bash)
 ├── briefing.ps1                 # Windows entry point (PowerShell)
@@ -505,6 +510,7 @@ ai-news-briefing/
 ├── backups/                     # Prompt backups (git-ignored)
 ├── .gitignore
 ├── ARCHITECTURE.md              # Detailed architecture documentation
+├── E2E_FLOW.md                  # End-to-end pipeline walkthrough
 ├── NOTIFY_TEAMS.md              # Teams integration setup guide
 └── README.md                    # This file
 ```

--- a/briefing.ps1
+++ b/briefing.ps1
@@ -1,10 +1,15 @@
 #Requires -Version 5.1
+
+param(
+    [string]$BriefingDate = ""
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $LogDir = Join-Path $ScriptDir "logs"
-$Date = Get-Date -Format "yyyy-MM-dd"
+$Date = if ($BriefingDate) { $BriefingDate } else { Get-Date -Format "yyyy-MM-dd" }
 $Time = Get-Date -Format "HH:mm:ss"
 $LogFile = Join-Path $LogDir "$Date.log"
 $Claude = Join-Path $env:USERPROFILE ".local\bin\claude.exe"
@@ -27,6 +32,22 @@ Write-Log "Starting AI News Briefing..."
 $PromptFile = Join-Path $ScriptDir "prompt.md"
 $Prompt = Get-Content -Path $PromptFile -Raw
 
+# Inject date override if running for a non-today date
+$today = Get-Date -Format "yyyy-MM-dd"
+if ($Date -ne $today) {
+    $datePrefix = @"
+BRIEFING DATE OVERRIDE: $Date
+Generate the briefing for $Date, NOT today ($today).
+Search for AI news from $Date (past 24 hours relative to that date).
+The Notion page title should use $Date.
+The card.json filename should use $Date (logs/$Date-card.json).
+---
+
+"@
+    $Prompt = $datePrefix + $Prompt
+    Write-Log "Date override: generating briefing for $Date"
+}
+
 try {
     $output = & $Claude -p `
         --model sonnet `
@@ -42,10 +63,11 @@ try {
 
         # Post summary to Teams channel if webhook is configured
         $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
+        $cardFile = Join-Path $LogDir "$Date-card.json"
         if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
             Write-Log "Sending Teams notification..."
             try {
-                & $teamsScript -LogFile $LogFile
+                & $teamsScript -CardFile $cardFile
                 Write-Log "Teams notification sent."
             } catch {
                 Write-Log "Teams notification failed: $_"

--- a/briefing.sh
+++ b/briefing.sh
@@ -3,7 +3,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
-DATE=$(date +%Y-%m-%d)
+DATE="${1:-$(date +%Y-%m-%d)}"
+TODAY=$(date +%Y-%m-%d)
 TIME=$(date +%H:%M:%S)
 LOG_FILE="$LOG_DIR/$DATE.log"
 CLAUDE="${HOME}/.local/bin/claude"
@@ -15,6 +16,23 @@ mkdir -p "$LOG_DIR"
 
 echo "[$DATE $TIME] Starting AI News Briefing..." >> "$LOG_FILE"
 
+# Read prompt
+PROMPT="$(cat "$SCRIPT_DIR/prompt.md")"
+
+# Inject date override if running for a non-today date
+if [[ "$DATE" != "$TODAY" ]]; then
+  DATE_PREFIX="BRIEFING DATE OVERRIDE: $DATE
+Generate the briefing for $DATE, NOT today ($TODAY).
+Search for AI news from $DATE (past 24 hours relative to that date).
+The Notion page title should use $DATE.
+The card.json filename should use $DATE (logs/$DATE-card.json).
+---
+
+"
+  PROMPT="${DATE_PREFIX}${PROMPT}"
+  echo "[$DATE $(date +%H:%M:%S)] Date override: generating briefing for $DATE" >> "$LOG_FILE"
+fi
+
 # Run Claude in print mode with the news prompt
 # --model sonnet: cost-efficient for search+compilation
 # --dangerously-skip-permissions: required for headless/automated execution
@@ -23,7 +41,7 @@ echo "[$DATE $TIME] Starting AI News Briefing..." >> "$LOG_FILE"
   --model sonnet \
   --dangerously-skip-permissions \
   --max-budget-usd 2.00 \
-  "$(cat "$SCRIPT_DIR/prompt.md")" \
+  "$PROMPT" \
   >> "$LOG_FILE" 2>&1
 
 EXIT_CODE=$?
@@ -34,9 +52,10 @@ if [ $EXIT_CODE -eq 0 ]; then
 
   # Post summary to Teams channel if webhook is configured
   TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
+  CARD_FILE="$LOG_DIR/$DATE-card.json"
   if [[ -x "$TEAMS_SCRIPT" && -n "${AI_BRIEFING_TEAMS_WEBHOOK:-}" ]]; then
     echo "[$DATE $(date +%H:%M:%S)] Sending Teams notification..." >> "$LOG_FILE"
-    if "$TEAMS_SCRIPT" --log-file "$LOG_FILE"; then
+    if "$TEAMS_SCRIPT" --card-file "$CARD_FILE"; then
       echo "[$DATE $(date +%H:%M:%S)] Teams notification sent." >> "$LOG_FILE"
     else
       echo "[$DATE $(date +%H:%M:%S)] Teams notification failed." >> "$LOG_FILE"

--- a/scripts/notify-teams.ps1
+++ b/scripts/notify-teams.ps1
@@ -1,14 +1,16 @@
 #Requires -Version 5.1
 
-# notify-teams.ps1 — Post today's AI briefing to a Teams channel via webhook.
+# notify-teams.ps1 — POST a pre-built Adaptive Card JSON to Teams webhook.
+# The AI generates the card JSON directly. This script just sends it.
+#
 # Usage:
-#   .\scripts\notify-teams.ps1                          # Auto-detect from today's log
-#   .\scripts\notify-teams.ps1 -WebhookUrl "https://..."  # Override webhook URL
-#   .\scripts\notify-teams.ps1 -LogFile "path\to.log"     # Use specific log file
+#   .\scripts\notify-teams.ps1
+#   .\scripts\notify-teams.ps1 -WebhookUrl "https://..."
+#   .\scripts\notify-teams.ps1 -CardFile "path\to\card.json"
 
 param(
     [string]$WebhookUrl = $env:AI_BRIEFING_TEAMS_WEBHOOK,
-    [string]$LogFile = ""
+    [string]$CardFile = ""
 )
 
 Set-StrictMode -Version Latest
@@ -17,61 +19,35 @@ $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 $Date = Get-Date -Format "yyyy-MM-dd"
 
-if (-not $LogFile) {
-    $LogFile = Join-Path (Join-Path $ScriptDir "logs") "$Date.log"
+if (-not $CardFile) {
+    $CardFile = Join-Path (Join-Path $ScriptDir "logs") "$Date-card.json"
 }
 
 if (-not $WebhookUrl) {
-    Write-Error "No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK env var or pass -WebhookUrl."
+    Write-Error "No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK or pass -WebhookUrl."
     exit 1
 }
 
-if (-not (Test-Path $LogFile)) {
-    Write-Error "Log file not found: $LogFile"
+if (-not (Test-Path $CardFile)) {
+    Write-Error "Card file not found: $CardFile"
     exit 1
 }
 
-$logContent = Get-Content $LogFile -Raw -Encoding utf8
-
-if ($logContent -notmatch "Briefing complete") {
-    Write-Host "Briefing did not complete successfully. Skipping Teams notification."
-    exit 0
-}
-
-# Use shared Python builder for the Adaptive Card JSON
-$builderScript = Join-Path (Join-Path $ScriptDir "scripts") "build-teams-card.py"
-if (-not (Test-Path $builderScript)) {
-    Write-Error "build-teams-card.py not found at $builderScript"
+# Validate JSON before sending
+try {
+    $null = Get-Content $CardFile -Raw -Encoding utf8 | ConvertFrom-Json
+} catch {
+    Write-Error "$CardFile is not valid JSON: $_"
     exit 1
 }
 
-# Build JSON via Python using Process API for clean stdout capture
-$psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = "python3"
-$psi.Arguments = "`"$builderScript`" `"$LogFile`""
-$psi.UseShellExecute = $false
-$psi.RedirectStandardOutput = $true
-$psi.RedirectStandardError = $true
-$psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
-$psi.CreateNoWindow = $true
-
-$proc = [System.Diagnostics.Process]::Start($psi)
-$jsonPayload = $proc.StandardOutput.ReadToEnd()
-$stderrOutput = $proc.StandardError.ReadToEnd()
-$proc.WaitForExit()
-
-if ($proc.ExitCode -ne 0) {
-    Write-Error "Failed to build Teams card: $stderrOutput"
-    exit 1
-}
-
-$bytes = [System.Text.Encoding]::UTF8.GetBytes($jsonPayload)
+$bytes = [System.IO.File]::ReadAllBytes($CardFile)
 
 try {
     $response = Invoke-RestMethod -Uri $WebhookUrl -Method Post -Body $bytes -ContentType "application/json; charset=utf-8"
     Write-Host "Teams notification sent successfully."
 } catch {
     $status = $_.Exception.Response.StatusCode.value__
-    Write-Host "Teams notification failed (HTTP $status): $_"
+    Write-Error "Teams notification failed (HTTP $status): $_"
     exit 1
 }

--- a/scripts/notify-teams.sh
+++ b/scripts/notify-teams.sh
@@ -1,56 +1,52 @@
 #!/bin/bash
 set -euo pipefail
 
-# notify-teams.sh — Post today's AI briefing TL;DR to a Teams channel via webhook.
+# notify-teams.sh — POST a pre-built Adaptive Card JSON to Teams webhook.
+# The AI generates the card JSON directly. This script just sends it.
+#
 # Usage:
-#   ./scripts/notify-teams.sh                              # Auto-detect from today's log
-#   ./scripts/notify-teams.sh --webhook-url "https://..."  # Override webhook URL
-#   ./scripts/notify-teams.sh --log-file "path/to.log"     # Use specific log file
+#   ./scripts/notify-teams.sh
+#   ./scripts/notify-teams.sh --webhook-url "https://..."
+#   ./scripts/notify-teams.sh --card-file "path/to/card.json"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 DATE=$(date +%Y-%m-%d)
 
 WEBHOOK_URL="${AI_BRIEFING_TEAMS_WEBHOOK:-}"
-LOG_FILE=""
+CARD_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --webhook-url) WEBHOOK_URL="$2"; shift 2 ;;
-    --log-file)    LOG_FILE="$2";    shift 2 ;;
+    --card-file)   CARD_FILE="$2";   shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
-if [[ -z "$LOG_FILE" ]]; then
-  LOG_FILE="$SCRIPT_DIR/logs/$DATE.log"
+if [[ -z "$CARD_FILE" ]]; then
+  CARD_FILE="$SCRIPT_DIR/logs/$DATE-card.json"
 fi
 
 if [[ -z "$WEBHOOK_URL" ]]; then
-  echo "Error: No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK env var or pass --webhook-url." >&2
+  echo "Error: No webhook URL. Set AI_BRIEFING_TEAMS_WEBHOOK or pass --webhook-url." >&2
   exit 1
 fi
 
-if [[ ! -f "$LOG_FILE" ]]; then
-  echo "Error: Log file not found: $LOG_FILE" >&2
+if [[ ! -f "$CARD_FILE" ]]; then
+  echo "Error: Card file not found: $CARD_FILE" >&2
   exit 1
 fi
 
-if ! grep -q "Briefing complete" "$LOG_FILE"; then
-  echo "Briefing did not complete successfully. Skipping Teams notification."
-  exit 0
+# Validate it's actual JSON before sending
+if ! python3 -m json.tool "$CARD_FILE" > /dev/null 2>&1; then
+  echo "Error: $CARD_FILE is not valid JSON." >&2
+  exit 1
 fi
 
-# Build the Adaptive Card JSON payload
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-python3 "$SCRIPT_DIR/scripts/build-teams-card.py" "$LOG_FILE" > "$TMPFILE"
-
-# POST to webhook using file input (avoids shell encoding issues)
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST \
   -H "Content-Type: application/json; charset=utf-8" \
-  -d @"$TMPFILE" \
+  -d @"$CARD_FILE" \
   "$WEBHOOK_URL")
 
 if [[ "$HTTP_CODE" =~ ^2 ]]; then


### PR DESCRIPTION
- Transitioned from using a Python script for building Teams Adaptive Cards to direct JSON file generation by the Claude Code AI agent.
- Updated `NOTIFY_TEAMS.md` to reflect the new workflow, including changes in setup, validation, and delivery processes.
- Revised `README.md` to clarify the automated pipeline and remove references to the legacy Python card builder.
- Enhanced `briefing.sh` and `briefing.ps1` to support date overrides for backfilling briefings.
- Modified `notify-teams.sh` and `notify-teams.ps1` to validate and POST pre-built card JSON files directly to Teams.
- Added `E2E_FLOW.md` to document the end-to-end flow of the AI news briefing pipeline.
- Removed legacy code and references to the Python card builder, streamlining the notification process.