### PR TITLE
docs: update usage note in build-teams-card.py for clarity

### DIFF
--- a/scripts/build-teams-card.py
+++ b/scripts/build-teams-card.py
@@ -2,6 +2,8 @@
 
 Usage: python3 build-teams-card.py <log_file>
 Writes JSON to stdout (UTF-8).
+
+Note: Not used actively anymore, since we now delegate card building to the AI, but still useful for debugging and as a reference implementation for the expected card structure.
 """
 
 import json


### PR DESCRIPTION
This pull request makes a minor documentation update to the `build-teams-card.py` script. It clarifies that the script is no longer actively used, as card building is now handled by the AI, but notes that the script remains useful for debugging and as a reference for the expected card structure.