### PR TITLE
feat: multi-CLI engine support with automatic fallback chain

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,9 @@
 ![Anthropic](https://img.shields.io/badge/Anthropic-Claude_Opus_4.6-6366f1?logo=anthropic&logoColor=white)
 ![Multi-Agent](https://img.shields.io/badge/Multi--Agent-5+_Parallel_Agents-8b5cf6?logo=anthropic&logoColor=white)
 ![Custom Brief](https://img.shields.io/badge/Custom_Brief-Deep_Research-ec4899?logo=anthropic&logoColor=white)
+![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-CLI-10b981?logo=openaigym&logoColor=white)
+![Google Gemini](https://img.shields.io/badge/Google_Gemini-CLI-4285F4?logo=googlegemini&logoColor=white)
+![GitHub Copilot CLI](https://img.shields.io/badge/GitHub_Copilot-CLI-238636?logo=githubcopilot&logoColor=white)
 ![WebSearch Tool](https://img.shields.io/badge/WebSearch_Tool-Integrated-10b981?logo=claude&logoColor=white)
 ![Notion](https://img.shields.io/badge/Notion-MCP-000000?logo=notion&logoColor=white)
 ![MCP](https://img.shields.io/badge/Model_Context_Protocol-1.0-10b981?logo=modelcontextprotocol&logoColor=white)
@@ -23,7 +26,7 @@
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-This document describes the architecture, data flow, and design decisions behind the AI News Briefing system -- an automated daily AI news aggregation pipeline that uses Claude Code to search the web, compile a structured briefing, and publish it to Notion.
+This document describes the architecture, data flow, and design decisions behind the AI News Briefing system -- an automated daily AI news aggregation pipeline that uses one of four supported AI CLI engines (Claude Code, Codex, Gemini, Copilot) to search the web, compile a structured briefing, and publish it to Notion.
 
 The system is cross-platform, supporting macOS (launchd) and Windows (Task Scheduler).
 
@@ -53,7 +56,7 @@ The system is cross-platform, supporting macOS (launchd) and Windows (Task Sched
 
 ## 1. System Architecture Overview
 
-The system is composed of four primary layers: a platform-native scheduler, a scripted entry point, the Claude Code AI engine, and the Notion API as the output destination. The core logic (prompt, search, compilation, Notion write, card generation) is identical across platforms -- only the scheduling and scripting layers differ.
+The system is composed of five primary layers: a platform-native scheduler, a scripted entry point, a CLI engine selection layer, the AI engine itself, and the Notion API as the output destination. The engine selection layer implements a registry pattern -- it checks for installed engines (Claude Code, Codex, Gemini, Copilot) and selects one based on the `AI_BRIEFING_CLI` environment variable or an automatic fallback chain (`claude` → `codex` → `gemini` → `copilot`). The core logic (prompt, search, compilation, Notion write, card generation) is identical across platforms and engines -- only the scheduling, scripting, and engine selection layers differ.
 
 ```mermaid
 graph TD
@@ -62,11 +65,15 @@ graph TD
         A2[Windows Task Scheduler] -->|8:00 AM daily| B2[briefing.ps1]
     end
 
+    subgraph "Engine Selection"
+        B1 -->|AI_BRIEFING_CLI or fallback| ES[Engine Registry]
+        B2 -->|AI_BRIEFING_CLI or fallback| ES
+        ES -->|Selects| D[AI Engine - Claude/Codex/Gemini/Copilot]
+    end
+
     subgraph "Shared Pipeline"
         B1 -->|Reads| P[prompt.md]
         B2 -->|Reads| P
-        B1 -->|Invokes| D[Claude Code CLI - Sonnet Model]
-        B2 -->|Invokes| D
         D -->|WebSearch tool| E[Web Sources]
         D -->|Notion MCP tool| F[Notion API]
         F --> G[Notion Page - AI Daily Briefing]
@@ -92,7 +99,8 @@ graph TD
 
 **Key design principles:**
 
-- **Headless execution.** The entire pipeline runs without user interaction via `claude -p` (print mode).
+- **Headless execution.** The entire pipeline runs without user interaction via the selected engine's headless/print mode.
+- **Multi-engine support.** Four AI CLI engines are supported (Claude Code, Codex, Gemini, Copilot) with automatic fallback. The `AI_BRIEFING_CLI` env var overrides the fallback chain, and `AI_BRIEFING_MODEL` overrides the default model.
 - **Cross-platform.** Platform-specific code is isolated to the entry point scripts and scheduler configs. The prompt, search strategy, and output format are shared.
 - **Single responsibility.** Each file has one job: scheduling, orchestration, prompt definition, or installation.
 - **Cost containment.** A hard budget cap of $2.00 per run prevents runaway API costs.
@@ -937,11 +945,27 @@ graph TD
 | WebSearch failure (all topics) | Claude cannot gather any news | Empty briefing or failure | Failed run logged |
 | Notion API error | MCP tool returns error | Claude reports in stdout | No page created |
 | Claude binary not found | Script exits on error | Logged as failure | No briefing |
+| Engine not found (fallback mode) | Engine binary missing from PATH | Try next engine in chain | Transparent to user |
+| All engines exhausted | No installed engine found | Logged as failure | No briefing |
 | Log directory permission error | Directory creation fails | Script exits immediately | No briefing, no log |
 
 ### Budget Safety
 
 The `--max-budget-usd 2.00` flag is the primary cost control mechanism. Claude Code tracks cumulative API costs during the run and terminates if the budget is exceeded. Based on observed runs, a typical briefing consumes well under this cap.
+
+### Engine Fallback Chain
+
+When `AI_BRIEFING_CLI` is not set, the entry scripts implement a fallback chain to find a working AI CLI engine:
+
+1. Check if `claude` is on PATH → use Claude Code
+2. Check if `codex` is on PATH → use Codex (OpenAI)
+3. Check if `gemini` is on PATH → use Gemini (Google)
+4. Check if `copilot` is on PATH → use Copilot (GitHub)
+5. If none found → exit with error and log failure
+
+When `AI_BRIEFING_CLI` is explicitly set, only that engine is tried. This is useful for CI environments or when you want deterministic engine selection.
+
+Each engine is invoked with equivalent flags for headless mode, model selection, and budget caps. The `AI_BRIEFING_MODEL` env var overrides the default model regardless of which engine is selected.
 
 ---
 
@@ -1079,7 +1103,11 @@ Edit `prompt.md`, Section "Topics to Search". Update the `Topics` property value
 
 ### Changing the AI Model
 
-Change `--model sonnet` in the entry script for your platform. Consider adjusting `--max-budget-usd` accordingly.
+Set the `AI_BRIEFING_MODEL` environment variable, or change `--model sonnet` in the entry script for your platform. Consider adjusting `--max-budget-usd` accordingly. The model override applies to whichever engine is selected.
+
+### Multi-Engine Support
+
+**Implemented.** Four AI CLI engines are supported: Claude Code, Codex (OpenAI), Gemini (Google), and Copilot (GitHub). The system uses an engine registry pattern with automatic fallback. Set `AI_BRIEFING_CLI` to force a specific engine, or let the fallback chain select the first available. See [Section 8](#8-error-handling) for fallback chain details.
 
 ### Custom Topic Research
 
@@ -1101,7 +1129,7 @@ The system could be extended to Linux by:
 
 1. Reusing `briefing.sh` as-is (bash is available on Linux).
 2. Creating a systemd timer + service unit (analogous to the launchd plist) or a cron entry.
-3. No changes to `prompt.md` or the Claude Code invocation.
+3. No changes to `prompt.md` or the AI engine invocation.
 
 ### Adding a Web Dashboard
 

--- a/CUSTOM_BRIEF.md
+++ b/CUSTOM_BRIEF.md
@@ -8,7 +8,7 @@ This feature complements the daily AI news briefing by letting you go deep on a 
 
 ## How It Works
 
-The custom brief runs a multi-phase research pipeline powered by Claude Code in headless mode. It spawns 5 parallel research agents, each covering a distinct angle, then synthesizes their findings into a structured briefing.
+The custom brief runs a multi-phase research pipeline powered by your selected AI CLI engine in headless mode. It spawns 5 parallel research agents, each covering a distinct angle, then synthesizes their findings into a structured briefing.
 
 ```mermaid
 flowchart TD
@@ -19,7 +19,7 @@ flowchart TD
 
     subgraph "Research Pipeline"
         CLI -->|Injects topic + flags| P[prompt-custom-brief.md]
-        P -->|"claude -p --model opus"| C[Claude Code CLI]
+        P -->|"claude/codex/gemini/copilot -p"| C[AI Engine]
 
         C -->|Phase 1: Parallel| A1[Agent 1: Breaking News]
         C -->|Phase 1: Parallel| A2[Agent 2: Technical Analysis]
@@ -74,6 +74,10 @@ flowchart TD
 
 # Short flags
 ./custom-brief.sh -t "AI regulation EU" -n
+
+# Use a specific engine
+./custom-brief.sh --cli codex --topic "AI safety" --notion
+./custom-brief.sh --cli gemini -t "quantum computing" -n
 ```
 
 **PowerShell:**
@@ -81,6 +85,7 @@ flowchart TD
 ```powershell
 .\custom-brief.ps1 -Topic "AI in healthcare" -Notion -Teams -Slack
 .\custom-brief.ps1 -Topic "quantum computing" -Notion
+.\custom-brief.ps1 -Cli gemini -Topic "AI safety" -Notion
 ```
 
 **Make:**
@@ -88,12 +93,13 @@ flowchart TD
 ```bash
 make custom-brief T="AI in healthcare" NOTION=1 TEAMS=1
 make custom-brief T="quantum computing" NOTION=1
+make custom-brief T="AI safety" CLI=codex NOTION=1
 make custom-brief-bg T="open source LLMs" NOTION=1  # background
 ```
 
 ### Interactive REPL
 
-Run without arguments to enter interactive mode:
+Run without arguments to enter interactive mode. The REPL shows which AI engines are available (✓/✗) and lets you pick one:
 
 ```bash
 ./custom-brief.sh
@@ -102,6 +108,11 @@ Run without arguments to enter interactive mode:
 ```
   Custom Brief -- Interactive Mode
   ================================
+
+  Available engines:
+    ✓ claude    ✓ codex    ✗ gemini    ✓ copilot
+
+  Engine [claude]: codex
 
   Topic: AI in drug discovery
 
@@ -129,6 +140,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | Flag | Description |
 |------|-------------|
 | `--topic`, `-t` | Topic to research (required in non-interactive mode) |
+| `--cli` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `--notion`, `-n` | Publish briefing to Notion |
 | `--teams` | Send Adaptive Card to Teams |
 | `--slack` | Send Block Kit message to Slack |
@@ -139,6 +151,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | Parameter | Description |
 |-----------|-------------|
 | `-Topic` | Topic to research (required in non-interactive mode) |
+| `-Cli` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `-Notion` | Publish briefing to Notion |
 | `-Teams` | Send Adaptive Card to Teams |
 | `-Slack` | Send Block Kit message to Slack |
@@ -148,6 +161,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | Variable | Description |
 |----------|-------------|
 | `T` | Topic (required) |
+| `CLI` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `NOTION` | Set to `1` to publish to Notion |
 | `TEAMS` | Set to `1` to send to Teams |
 | `SLACK` | Set to `1` to send to Slack |
@@ -240,7 +254,7 @@ flowchart LR
 
 Same as the daily briefing:
 
-- Claude Code CLI installed at `~/.local/bin/claude`
+- At least one AI CLI engine installed: Claude Code (`claude`), Codex (`codex`), Gemini (`gemini`), or Copilot (`copilot`)
 - Notion MCP configured (for `--notion`)
 - `AI_BRIEFING_TEAMS_WEBHOOK` env var set (for `--teams`)
 - `AI_BRIEFING_SLACK_WEBHOOK` env var set (for `--slack`)

--- a/Makefile
+++ b/Makefile
@@ -43,44 +43,47 @@ help: ## Show this help
 	@echo ""
 
 ## —— Run ——————————————————————————————————————————————
-run: check ## Run the briefing now (foreground). Backfill: make run D=2026-03-15
+run: check ## Run the briefing now (foreground). Options: D=2026-03-15 CLI=codex
 ifeq ($(PLATFORM),windows)
-	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D))
+	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D)) $(if $(CLI),-Cli $(CLI))
 else
-	@bash "$(SCRIPT_DIR)/briefing.sh" $(D)
+	@bash "$(SCRIPT_DIR)/briefing.sh" $(if $(D),--date $(D)) $(if $(CLI),--cli $(CLI))
 endif
 
-run-bg: check ## Run the briefing in background. Backfill: make run-bg D=2026-03-15
+run-bg: check ## Run the briefing in background. Options: D=2026-03-15 CLI=codex
 ifeq ($(PLATFORM),windows)
 	@echo "[$(or $(D),$(DATE))] Starting briefing in background..."
-	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D)) &
+	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/briefing.ps1" $(if $(D),-BriefingDate $(D)) $(if $(CLI),-Cli $(CLI)) &
 	@echo "Running. Tail log with: make tail"
 else
 	@echo "[$(or $(D),$(DATE))] Starting briefing in background..."
-	@nohup bash "$(SCRIPT_DIR)/briefing.sh" $(D) >/dev/null 2>&1 &
+	@nohup bash "$(SCRIPT_DIR)/briefing.sh" $(if $(D),--date $(D)) $(if $(CLI),--cli $(CLI)) >/dev/null 2>&1 &
 	@echo "Running (PID $$!). Tail log with: make tail"
 endif
 
-custom-brief: check ## Deep-research a topic. Usage: make custom-brief T="AI in healthcare" NOTION=1 TEAMS=1 SLACK=1
+custom-brief: check ## Deep-research a topic. Usage: make custom-brief T="topic" CLI=codex NOTION=1 TEAMS=1 SLACK=1
 ifeq ($(PLATFORM),windows)
 	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/custom-brief.ps1" \
 		$(if $(T),-Topic "$(T)") \
+		$(if $(CLI),-Cli $(CLI)) \
 		$(if $(NOTION),-Notion) \
 		$(if $(TEAMS),-Teams) \
 		$(if $(SLACK),-Slack)
 else
 	@bash "$(SCRIPT_DIR)/custom-brief.sh" \
 		$(if $(T),--topic "$(T)") \
+		$(if $(CLI),--cli $(CLI)) \
 		$(if $(NOTION),--notion) \
 		$(if $(TEAMS),--teams) \
 		$(if $(SLACK),--slack)
 endif
 
-custom-brief-bg: check ## Deep-research in background. Usage: make custom-brief-bg T="quantum computing" NOTION=1
+custom-brief-bg: check ## Deep-research in background. Usage: make custom-brief-bg T="topic" CLI=gemini NOTION=1
 ifeq ($(PLATFORM),windows)
 	@echo "Starting custom brief in background..."
 	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/custom-brief.ps1" \
 		$(if $(T),-Topic "$(T)") \
+		$(if $(CLI),-Cli $(CLI)) \
 		$(if $(NOTION),-Notion) \
 		$(if $(TEAMS),-Teams) \
 		$(if $(SLACK),-Slack) &
@@ -89,6 +92,7 @@ else
 	@echo "Starting custom brief in background..."
 	@nohup bash "$(SCRIPT_DIR)/custom-brief.sh" \
 		$(if $(T),--topic "$(T)") \
+		$(if $(CLI),--cli $(CLI)) \
 		$(if $(NOTION),--notion) \
 		$(if $(TEAMS),--teams) \
 		$(if $(SLACK),--slack) >/dev/null 2>&1 &
@@ -188,13 +192,23 @@ else
 endif
 
 ## —— Validate —————————————————————————————————————————
-check: ## Verify Claude CLI is installed and accessible
-	@if [ ! -f "$(CLAUDE)" ]; then \
-		echo "ERROR: Claude CLI not found at $(CLAUDE)"; \
-		echo "Install it or update the path in the entry script."; \
+check: ## Verify at least one supported AI CLI is installed
+	@found=0; \
+	for cli in claude codex gemini copilot gh; do \
+		if command -v $$cli >/dev/null 2>&1; then \
+			printf "  %-12s \033[32mOK\033[0m (%s)\n" "$$cli" "$$(command -v $$cli)"; \
+			found=1; \
+		fi; \
+	done; \
+	if [ -f "$(CLAUDE)" ]; then \
+		printf "  %-12s \033[32mOK\033[0m (%s)\n" "claude" "$(CLAUDE)"; \
+		found=1; \
+	fi; \
+	if [ $$found -eq 0 ]; then \
+		echo "ERROR: No supported AI CLI found (claude, codex, gemini, copilot)."; \
+		echo "Install at least one. See README.md for details."; \
 		exit 1; \
 	fi
-	@echo "Claude CLI: OK ($(CLAUDE))"
 
 validate: check ## Validate all project files exist and are well-formed
 	@echo "Checking project files..."
@@ -235,12 +249,20 @@ info: ## Show project configuration summary
 	@echo "  ═════════════════════════════════"
 	@echo ""
 	@echo "  Platform:    $(PLATFORM)"
-	@echo "  Claude CLI:  $(CLAUDE)"
 	@echo "  Script dir:  $(SCRIPT_DIR)"
 	@echo "  Log dir:     $(LOG_DIR)"
 	@echo "  Today's log: $(LOG_FILE)"
 	@echo ""
-	@echo "  Model:       $$(grep -o '\-\-model [a-z]*' "$(SCRIPT_DIR)/briefing.sh" | head -1 | awk '{print $$2}')"
-	@echo "  Budget cap:  $$(grep -o '\-\-max-budget-usd [0-9.]*' "$(SCRIPT_DIR)/briefing.sh" | head -1 | awk '{print $$2}')"
+	@echo "  CLI pref:    $${AI_BRIEFING_CLI:-auto (claude > codex > gemini > copilot)}"
+	@echo "  Model:       $${AI_BRIEFING_MODEL:-opus}"
 	@echo "  Topics:      $$(grep -c '^\d\.' "$(SCRIPT_DIR)/prompt.md" 2>/dev/null || echo 9)"
+	@echo ""
+	@echo "  Engines installed:"
+	@for cli in claude codex gemini copilot; do \
+		if command -v $$cli >/dev/null 2>&1; then \
+			printf "    %-12s \033[32m✓\033[0m\n" "$$cli"; \
+		else \
+			printf "    %-12s \033[2m✗\033[0m\n" "$$cli"; \
+		fi; \
+	done
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ![Anthropic](https://img.shields.io/badge/Anthropic-Claude_Opus_4.6-6366f1?logo=anthropic&logoColor=white)
 ![Multi-Agent](https://img.shields.io/badge/Multi--Agent-5+_Parallel_Agents-8b5cf6?logo=anthropic&logoColor=white)
 ![Custom Brief](https://img.shields.io/badge/Custom_Brief-Deep_Research-ec4899?logo=anthropic&logoColor=white)
+![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-CLI-10b981?logo=openaigym&logoColor=white)
+![Google Gemini](https://img.shields.io/badge/Google_Gemini-CLI-4285F4?logo=googlegemini&logoColor=white)
+![GitHub Copilot CLI](https://img.shields.io/badge/GitHub_Copilot-CLI-238636?logo=githubcopilot&logoColor=white)
 ![WebSearch Tool](https://img.shields.io/badge/WebSearch_Tool-Integrated-10b981?logo=claude&logoColor=white)
 ![Notion](https://img.shields.io/badge/Notion-MCP-000000?logo=notion&logoColor=white)
 ![MCP](https://img.shields.io/badge/Model_Context_Protocol-1.0-10b981?logo=modelcontextprotocol&logoColor=white)
@@ -23,7 +26,7 @@
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams and Slack -- powered by Claude Code CLI. Supports both macOS (launchd) and Windows (Task Scheduler). Includes an on-demand **Custom Brief** mode for deep multi-agent research on any topic. Fully automated pipeline with zero manual intervention required after setup.
+Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams and Slack -- powered by Claude Code, Codex, Gemini, or Copilot CLIs with automatic fallback. Supports both macOS (launchd) and Windows (Task Scheduler). Includes an on-demand **Custom Brief** mode for deep multi-agent research on any topic. Fully automated pipeline with zero manual intervention required after setup.
 
 > [!NOTE]
 > **Live AI News Notion page:** [https://hoangsonw.notion.site/9c34d052d9354beda82a3423e2d2f404?v=d43c53fe405c4896bfd95ad0cc22246f](https://hoangsonw.notion.site/9c34d052d9354beda82a3423e2d2f404?v=d43c53fe405c4896bfd95ad0cc22246f)
@@ -32,7 +35,7 @@ Automated daily AI news research agent that searches the web, compiles a structu
 
 ## Overview
 
-AI News Briefing is a fully automated pipeline that runs every morning on your machine. It uses Claude Code in headless mode to act as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), writing the finished page directly to a Notion database, and optionally posting a styled Adaptive Card summary to Microsoft Teams and Slack.
+AI News Briefing is a fully automated pipeline that runs every morning on your machine. It supports four AI CLI engines -- Claude Code, Codex (OpenAI), Gemini (Google), and Copilot (GitHub) -- with automatic fallback if your preferred engine is unavailable. The selected engine runs in headless mode as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), writing the finished page directly to a Notion database, and optionally posting a styled Adaptive Card summary to Microsoft Teams and Slack.
 
 The entire process -- from triggering to publishing -- requires zero human intervention. You wake up, open Notion (or Teams or Slack), and your daily AI briefing is already there.
 
@@ -46,7 +49,7 @@ Keeping up with AI news across models, tools, policy, funding, and open source i
 
 ## Architecture
 
-We leverage the scheduling capabilities of the OS (launchd on macOS, Task Scheduler on Windows) to trigger a shell script at a specific time each day. The script reads a prompt template, invokes the Claude Code CLI in headless mode, and the agentic prompt performs web searches, compiles results, and calls the Notion MCP tool to create a new page in the database.
+We leverage the scheduling capabilities of the OS (launchd on macOS, Task Scheduler on Windows) to trigger a shell script at a specific time each day. The script reads a prompt template, selects an AI CLI engine (via the `AI_BRIEFING_CLI` env var or automatic fallback: claude → codex → gemini → copilot), and invokes it in headless mode. The agentic prompt performs web searches, compiles results, and calls the Notion MCP tool to create a new page in the database.
 
 ```mermaid
 flowchart TD
@@ -61,7 +64,7 @@ flowchart TD
     B1 -->|Reads| C[prompt.md]
     B2 -->|Reads| C
 
-    B1 -->|Invokes| D[Claude Code CLI]
+    B1 -->|Invokes| D[AI Engine - Claude/Codex/Gemini/Copilot]
     B2 -->|Invokes| D
 
     D -->|Step 1: Search| E[WebSearch Tool]
@@ -92,8 +95,8 @@ flowchart TD
 **Data flow summary:**
 
 1. The platform scheduler fires the entry point script (`briefing.sh` on macOS, `briefing.ps1` on Windows) at the configured time each day.
-2. The script reads the prompt from `prompt.md` and passes it to the Claude Code CLI in print mode.
-3. Claude Code executes the prompt as an agentic task -- performing web searches, compiling results, and calling the Notion MCP tool.
+2. The script reads the prompt from `prompt.md` and passes it to the selected AI CLI engine in headless mode.
+3. The AI engine executes the prompt as an agentic task -- performing web searches, compiling results, and calling the Notion MCP tool.
 4. Notion receives the finished briefing as a new database page.
 5. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which validates and POSTs the pre-built `logs/YYYY-MM-DD-card.json` file (written by Claude in Step 4) to the configured Teams webhook.
 6. If the `AI_BRIEFING_SLACK_WEBHOOK` environment variable is set, the entry point script calls `notify-slack.sh` / `notify-slack.ps1`, which converts the Teams card to Slack Block Kit format and POSTs it to the configured Slack webhook.
@@ -106,9 +109,9 @@ flowchart TD
 | Requirement | Details |
 |---|---|
 | **OS** | macOS or Windows 10/11 |
-| **Claude Code CLI** | Installed at `~/.local/bin/claude` with a valid Anthropic API key or Max subscription |
-| **Notion MCP** | The Notion MCP server must be configured in Claude Code's MCP settings with access to your workspace |
-| **WebSearch tool** | Available by default in Claude Code (no extra setup needed) |
+| **At least one AI CLI** | Any of the following: **Claude Code** (`claude`), **Codex** (`codex`), **Gemini** (`gemini`), or **Copilot** (`copilot`). If multiple are installed, the system uses `AI_BRIEFING_CLI` or falls back automatically. |
+| **Notion MCP** | The Notion MCP server must be configured in your AI CLI's MCP settings with access to your workspace |
+| **WebSearch tool** | Available by default in most AI CLIs (no extra setup needed) |
 | **Python 3.x** | Optional (legacy card builder only, not used in current flow) |
 | **Make** (optional) | GNU Make for using the Makefile task runner (`winget install GnuWin32.Make` on Windows, pre-installed on macOS) |
 
@@ -190,14 +193,34 @@ launchctl load ~/Library/LaunchAgents/com.ainews.briefing.plist
 .\install-task.ps1 -Hour 9 -Minute 0
 ```
 
+### Change the AI engine
+
+Set the `AI_BRIEFING_CLI` environment variable to choose which engine to use:
+
+```bash
+export AI_BRIEFING_CLI=codex    # or: claude, gemini, copilot
+```
+
+If not set, the daily briefing tries engines in fallback order: `claude` → `codex` → `gemini` → `copilot`, using the first one found. For custom briefs, pass `--cli`:
+
+```bash
+./custom-brief.sh --cli gemini --topic "AI safety"
+```
+
 ### Change the model
 
-Edit the entry point script for your platform:
+Set the `AI_BRIEFING_MODEL` environment variable to override the default model for any engine:
+
+```bash
+export AI_BRIEFING_MODEL=opus
+```
+
+Or edit the entry point script for your platform:
 
 - **macOS:** `briefing.sh` -- change the `--model sonnet` flag
 - **Windows:** `briefing.ps1` -- change the `--model sonnet` argument
 
-**Model trade-offs:**
+**Model trade-offs (Claude Code):**
 
 | Model | Speed | Cost | Quality |
 |---|---|---|---|
@@ -226,9 +249,10 @@ Once installed, the briefing runs automatically every day at the scheduled time 
 **Using Make (recommended, cross-platform):**
 
 ```bash
-make run            # Run in foreground
+make run            # Run in foreground (auto-detects engine)
 make run-bg         # Run in background
 make run-scheduled  # Trigger via OS scheduler
+make run CLI=codex  # Use a specific engine
 ```
 
 **Platform-native:**
@@ -283,10 +307,11 @@ The project includes a cross-platform `Makefile` that auto-detects your OS and r
 | `make install` | Install platform scheduler |
 | `make uninstall` | Remove platform scheduler |
 | `make status` | Show scheduler status |
-| `make check` | Verify Claude CLI is installed |
+| `make check` | Verify at least one AI CLI is installed |
 | `make validate` | Validate all project files and prompt structure |
 | `make prompt` | Print the current prompt |
-| `make info` | Show config summary (model, budget, paths) |
+| `make info` | Show config summary (engines, model, paths) |
+| `CLI=<engine>` | Parameter: choose engine (`claude`, `codex`, `gemini`, `copilot`) |
 
 ### Utility Scripts Reference
 
@@ -487,14 +512,21 @@ flowchart LR
 # Terminal + Notion only
 ./custom-brief.sh -t "quantum computing" -n
 
-# Interactive mode (prompts for topic and destinations)
+# Use a specific engine
+./custom-brief.sh --cli codex --topic "AI safety" --notion
+
+# Interactive mode (prompts for topic, engine, and destinations)
 ./custom-brief.sh
 
 # PowerShell
 .\custom-brief.ps1 -Topic "AI regulation EU" -Notion -Teams
 
+# PowerShell with engine override
+.\custom-brief.ps1 -Cli gemini -Topic "AI regulation EU" -Notion
+
 # Make
 make custom-brief T="open source LLMs" NOTION=1 TEAMS=1
+make custom-brief T="AI safety" CLI=codex NOTION=1
 ```
 
 ### What it produces
@@ -670,6 +702,20 @@ If the log shows the run stopped mid-way, the `--max-budget-usd` cap may have be
 ### Multiple runs in the same day
 
 Running the briefing multiple times in a day updates the existing Notion page rather than creating a duplicate. The agent checks for an existing page during Step 0b and updates it if found. Logs append to the same date-stamped file, so all runs for a given day are captured in one log.
+
+### Out of quota / CLI unavailable
+
+If the configured engine is unavailable (not installed, quota exceeded, or authentication expired), the system handles it differently depending on the mode:
+
+- **Daily briefing (automatic fallback):** When `AI_BRIEFING_CLI` is not set, the entry script tries each engine in order: `claude` → `codex` → `gemini` → `copilot`. If an engine is not found on `PATH`, it is skipped. If all engines fail, the run is logged as a failure.
+- **Daily briefing (explicit engine):** When `AI_BRIEFING_CLI` is set to a specific engine, only that engine is tried. If it fails, no fallback occurs and the run is logged as a failure.
+- **Custom brief:** In interactive mode, the REPL shows which engines are available (✓/✗) so you can pick one that works. In non-interactive mode, pass `--cli <engine>` to choose explicitly.
+
+To see which engines are installed on your machine:
+
+```bash
+make info
+```
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,23 +8,30 @@ Complete setup instructions for the AI News Briefing system, covering both the d
 
 | Requirement | Used by | Details |
 |---|---|---|
-| **Claude Code CLI** | Both | Installed at `~/.local/bin/claude` with a valid Anthropic API key or Max subscription |
-| **Notion MCP** | Both (optional) | The Notion MCP server configured in Claude Code's MCP settings |
-| **WebSearch tool** | Both | Built into Claude Code (no extra setup) |
+| **At least one AI CLI** | Both | Any of: **Claude Code** (`claude`), **Codex** (`codex`), **Gemini** (`gemini`), or **Copilot** (`copilot`). Multiple can be installed for fallback. |
+| **Notion MCP** | Both (optional) | The Notion MCP server configured in your AI CLI's MCP settings |
+| **WebSearch tool** | Both | Built into most AI CLIs (no extra setup) |
 | **Python 3.x** | Slack delivery | Required for `teams-to-slack.py` conversion |
 | **GNU Make** | Optional | For `make run`, `make custom-brief`, etc. (`winget install GnuWin32.Make` on Windows) |
 
 ---
 
-## 1. Install Claude Code CLI
+## 1. Install an AI CLI Engine
 
-Follow the official install guide at [code.claude.com](https://code.claude.com). Verify:
+You need at least one of the following CLI engines. Install one or more for fallback support:
+
+| Engine | Install | Verify |
+|---|---|---|
+| **Claude Code** | [code.claude.com](https://code.claude.com) | `claude --version` |
+| **Codex** | `npm install -g @openai/codex` | `codex --version` |
+| **Gemini** | `npm install -g @anthropic-ai/gemini-cli` or see [Google AI docs](https://ai.google.dev) | `gemini --version` |
+| **Copilot** | `npm install -g @githubnext/github-copilot-cli` or via GitHub CLI extension | `copilot --version` |
+
+The daily briefing auto-detects installed engines and falls back in order: `claude` → `codex` → `gemini` → `copilot`. Set `AI_BRIEFING_CLI` to force a specific engine:
 
 ```bash
-claude --version
+export AI_BRIEFING_CLI=codex
 ```
-
-The CLI should be at `~/.local/bin/claude` (macOS/Linux) or `%USERPROFILE%\.local\bin\claude.exe` (Windows).
 
 ---
 
@@ -162,6 +169,13 @@ bash scripts/health-check.sh
 .\scripts\health-check.ps1
 ```
 
+### Check installed engines
+
+```bash
+make info    # Shows all installed engines with ✓/✗ indicators
+make check   # Verifies at least one AI CLI is available
+```
+
 ### Test Notion connectivity
 
 ```bash
@@ -187,7 +201,7 @@ make custom-brief T="test topic"
 ```mermaid
 flowchart TD
     subgraph "Setup Steps"
-        S1[1. Install Claude Code CLI] --> S2[2. Clone repo]
+        S1[1. Install an AI CLI Engine] --> S2[2. Clone repo]
         S2 --> S3[3. Configure Notion MCP]
         S3 --> S4[4. Set webhook env vars]
         S4 --> S5[5. Install scheduler]

--- a/briefing.ps1
+++ b/briefing.ps1
@@ -1,32 +1,52 @@
 #Requires -Version 5.1
 
+<#
+.SYNOPSIS
+    Daily AI news briefing with multi-engine fallback.
+.DESCRIPTION
+    Runs the daily AI news briefing pipeline. Supports multiple AI CLI engines
+    (Claude Code, Codex, Gemini, Copilot) with automatic fallback if one fails.
+.PARAMETER BriefingDate
+    Override the briefing date (YYYY-MM-DD). Default: today.
+.PARAMETER Cli
+    AI engine to use: claude, codex, gemini, copilot.
+    If omitted, reads AI_BRIEFING_CLI env var; if unset, tries each in order.
+.EXAMPLE
+    .\briefing.ps1
+.EXAMPLE
+    .\briefing.ps1 -Cli codex
+.EXAMPLE
+    .\briefing.ps1 -BriefingDate 2026-04-01 -Cli gemini
+#>
+
 param(
-    [string]$BriefingDate = ""
+    [string]$BriefingDate = "",
+    [ValidateSet("claude", "codex", "gemini", "copilot", "")]
+    [string]$Cli = ""
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = "Continue"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $LogDir = Join-Path $ScriptDir "logs"
 $Date = if ($BriefingDate) { $BriefingDate } else { Get-Date -Format "yyyy-MM-dd" }
-$Time = Get-Date -Format "HH:mm:ss"
 $LogFile = Join-Path $LogDir "$Date.log"
-$Claude = Join-Path $env:USERPROFILE ".local\bin\claude.exe"
 
-# Ensure we can run even if Claude Code is open
+# Prevent nested Claude Code sessions
 $env:CLAUDECODE = $null
 
-# Refresh webhook env vars from registry (parent shell may have stale values)
-$regTeams = [Environment]::GetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "User")
-if ($regTeams) { $env:AI_BRIEFING_TEAMS_WEBHOOK = $regTeams }
-$regSlack = [Environment]::GetEnvironmentVariable("AI_BRIEFING_SLACK_WEBHOOK", "User")
-if ($regSlack) { $env:AI_BRIEFING_SLACK_WEBHOOK = $regSlack }
+# Refresh persistent env vars from registry
+foreach ($name in @("AI_BRIEFING_TEAMS_WEBHOOK", "AI_BRIEFING_SLACK_WEBHOOK", "AI_BRIEFING_CLI", "AI_BRIEFING_MODEL")) {
+    $val = [Environment]::GetEnvironmentVariable($name, "User")
+    if ($val) { [Environment]::SetEnvironmentVariable($name, $val, "Process") }
+}
 
 if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 }
 
+# -- Logging ---------------------------------------------------
 function Write-Log {
     param([string]$Message)
     $ts = Get-Date -Format "HH:mm:ss"
@@ -35,10 +55,88 @@ function Write-Log {
 
 Write-Log "Starting AI News Briefing..."
 
+# -- CLI Engine Registry ---------------------------------------
+$FallbackChain = @("claude", "codex", "gemini", "copilot")
+
+function Resolve-CliBinary {
+    param([string]$CliName)
+    switch ($CliName) {
+        "claude" {
+            foreach ($p in @(
+                (Join-Path $env:USERPROFILE ".local\bin\claude.exe"),
+                (Join-Path $env:USERPROFILE ".local\bin\claude")
+            )) {
+                if (Test-Path $p) { return $p }
+            }
+            $cmd = Get-Command "claude" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "codex" {
+            $cmd = Get-Command "codex" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "gemini" {
+            $cmd = Get-Command "gemini" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "copilot" {
+            $gh = Get-Command "gh" -ErrorAction SilentlyContinue
+            if ($gh) {
+                try {
+                    $exts = & gh extension list 2>$null
+                    if ($exts -match "copilot") { return $gh.Source }
+                } catch {}
+            }
+            $cmd = Get-Command "copilot" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        default { return $null }
+    }
+}
+
+function Invoke-Engine {
+    param(
+        [string]$CliName,
+        [string]$Binary,
+        [string]$Prompt
+    )
+
+    $model = if ($env:AI_BRIEFING_MODEL) { $env:AI_BRIEFING_MODEL } else { "opus" }
+
+    try {
+        $output = switch ($CliName) {
+            "claude"  { & $Binary -p --model $model --dangerously-skip-permissions $Prompt 2>&1 }
+            "codex"   { & $Binary -q --full-auto $Prompt 2>&1 }
+            "gemini"  { & $Binary -p $Prompt 2>&1 }
+            "copilot" {
+                if ($Binary -match '[/\\]gh(\.exe)?$') {
+                    & $Binary copilot -p $Prompt 2>&1
+                } else {
+                    & $Binary -p $Prompt 2>&1
+                }
+            }
+        }
+        $output | Out-File -FilePath $LogFile -Append -Encoding utf8
+        return $(if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 })
+    } catch {
+        "ERROR: $_" | Out-File -FilePath $LogFile -Append -Encoding utf8
+        return 1
+    }
+}
+
+# -- Prompt assembly -------------------------------------------
 $PromptFile = Join-Path $ScriptDir "prompt.md"
+if (-not (Test-Path $PromptFile)) {
+    Write-Log "ERROR: prompt.md not found at $PromptFile"
+    exit 1
+}
+
 $Prompt = Get-Content -Path $PromptFile -Raw
 
-# Inject date override if running for a non-today date
 $today = Get-Date -Format "yyyy-MM-dd"
 if ($Date -ne $today) {
     $datePrefix = @"
@@ -54,50 +152,82 @@ The card.json filename should use $Date (logs/$Date-card.json).
     Write-Log "Date override: generating briefing for $Date"
 }
 
-try {
-    $output = & $Claude -p `
-        --model opus `
-        --dangerously-skip-permissions `
-        $Prompt 2>&1
+# -- Execution with fallback -----------------------------------
+$Preferred = if ($Cli) { $Cli } elseif ($env:AI_BRIEFING_CLI) { $env:AI_BRIEFING_CLI } else { "" }
+$Success = $false
+$UsedCli = ""
 
-    $output | Out-File -FilePath $LogFile -Append -Encoding utf8
-    $exitCode = $LASTEXITCODE
-
-    if ($exitCode -eq 0) {
-        Write-Log "Briefing complete. Check Notion for today's report."
-
-        # Post summary to Teams channel if webhook is configured
-        $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
-        $cardFile = Join-Path $LogDir "$Date-card.json"
-        if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
-            Write-Log "Sending Teams notification..."
-            try {
-                & $teamsScript -All -CardFile $cardFile
-                Write-Log "Teams notification sent."
-            } catch {
-                Write-Log "Teams notification failed: $_"
-            }
-        }
-
-        # Post summary to Slack channel if webhook is configured
-        $slackScript = Join-Path $ScriptDir "scripts\notify-slack.ps1"
-        if ((Test-Path $slackScript) -and $env:AI_BRIEFING_SLACK_WEBHOOK) {
-            Write-Log "Sending Slack notification..."
-            try {
-                & $slackScript -All -CardFile $cardFile
-                Write-Log "Slack notification sent."
-            } catch {
-                Write-Log "Slack notification failed: $_"
-            }
-        }
-    } else {
-        Write-Log "Briefing FAILED with exit code $exitCode."
+if ($Preferred) {
+    # Explicit engine chosen
+    $binary = Resolve-CliBinary -CliName $Preferred
+    if (-not $binary) {
+        Write-Log "ERROR: Requested engine '$Preferred' is not installed."
+        exit 1
     }
-} catch {
-    Write-Log "Briefing FAILED with error: $_"
+    Write-Log "Engine: $Preferred ($binary)"
+
+    $exitCode = Invoke-Engine -CliName $Preferred -Binary $binary -Prompt $Prompt
+    if ($exitCode -eq 0) {
+        $Success = $true
+        $UsedCli = $Preferred
+    } else {
+        Write-Log "Briefing FAILED with $Preferred (exit code $exitCode)."
+    }
+} else {
+    # Fallback chain
+    foreach ($cli in $FallbackChain) {
+        $binary = Resolve-CliBinary -CliName $cli
+        if (-not $binary) {
+            Write-Log "Engine ${cli}: not found, skipping."
+            continue
+        }
+        Write-Log "Attempting with $cli ($binary)..."
+
+        $exitCode = Invoke-Engine -CliName $cli -Binary $binary -Prompt $Prompt
+        if ($exitCode -eq 0) {
+            $Success = $true
+            $UsedCli = $cli
+            break
+        }
+
+        Write-Log "$cli failed (exit $exitCode). Trying next engine..."
+    }
 }
 
-# Clean up logs older than 30 days
-Get-ChildItem -Path $LogDir -Filter "*.log" -File |
+# -- Post-processing -------------------------------------------
+if ($Success) {
+    Write-Log "Briefing complete. Engine: $UsedCli. Check Notion for today's report."
+
+    $CardFile = Join-Path $LogDir "$Date-card.json"
+
+    # Teams notification
+    $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
+    if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
+        Write-Log "Sending Teams notification..."
+        try {
+            & $teamsScript -All -CardFile $CardFile
+            Write-Log "Teams notification sent."
+        } catch {
+            Write-Log "Teams notification failed: $_"
+        }
+    }
+
+    # Slack notification
+    $slackScript = Join-Path $ScriptDir "scripts\notify-slack.ps1"
+    if ((Test-Path $slackScript) -and $env:AI_BRIEFING_SLACK_WEBHOOK) {
+        Write-Log "Sending Slack notification..."
+        try {
+            & $slackScript -All -CardFile $CardFile
+            Write-Log "Slack notification sent."
+        } catch {
+            Write-Log "Slack notification failed: $_"
+        }
+    }
+} else {
+    Write-Log "Briefing FAILED -- all engines exhausted or selected engine failed."
+}
+
+# -- Cleanup ---------------------------------------------------
+Get-ChildItem -Path $LogDir -Filter "*.log" -File -ErrorAction SilentlyContinue |
     Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) } |
     Remove-Item -Force -ErrorAction SilentlyContinue

--- a/briefing.sh
+++ b/briefing.sh
@@ -1,25 +1,153 @@
 #!/bin/bash
-set -e
+# AI News Briefing - Daily automated pipeline with multi-engine fallback.
+#
+# Supported engines: claude, codex, gemini, copilot
+# - Set AI_BRIEFING_CLI env var or pass --cli to lock to a specific engine
+# - If unset, tries each in order until one succeeds (claude -> codex -> gemini -> copilot)
+#
+# Usage:
+#   briefing.sh                                # today, auto-fallback
+#   briefing.sh 2026-04-01                     # backfill date (backward compat)
+#   briefing.sh --cli codex                    # lock to codex
+#   briefing.sh --cli gemini --date 2026-04-01 # both
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
-DATE="${1:-$(date +%Y-%m-%d)}"
+
+# -- Argument parsing ------------------------------------------
+CLI_ARG=""
+DATE_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cli|-c)
+      [[ $# -lt 2 ]] && { echo "ERROR: --cli requires a value" >&2; exit 1; }
+      CLI_ARG="$2"; shift 2 ;;
+    --date|-d)
+      [[ $# -lt 2 ]] && { echo "ERROR: --date requires a value" >&2; exit 1; }
+      DATE_ARG="$2"; shift 2 ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: briefing.sh [OPTIONS] [DATE]
+
+Run the daily AI news briefing pipeline.
+
+Options:
+  --cli, -c ENGINE   AI engine: claude, codex, gemini, copilot
+  --date, -d DATE    Briefing date (YYYY-MM-DD), default: today
+  --help, -h         Show this help
+
+Environment:
+  AI_BRIEFING_CLI    Default engine (overridden by --cli)
+  AI_BRIEFING_MODEL  Model name (default: opus for claude)
+USAGE
+      exit 0 ;;
+    -*)
+      echo "Unknown option: $1" >&2; exit 1 ;;
+    *)
+      DATE_ARG="$1"; shift ;;
+  esac
+done
+
+DATE="${DATE_ARG:-$(date +%Y-%m-%d)}"
 TODAY=$(date +%Y-%m-%d)
 TIME=$(date +%H:%M:%S)
 LOG_FILE="$LOG_DIR/$DATE.log"
-CLAUDE="${HOME}/.local/bin/claude"
 
-# Ensure we can run even if Claude Code is open
-unset CLAUDECODE
+# Prevent nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
 
 mkdir -p "$LOG_DIR"
 
-echo "[$DATE $TIME] Starting AI News Briefing..." >> "$LOG_FILE"
+# -- Logging ---------------------------------------------------
+write_log() {
+  echo "[$DATE $(date +%H:%M:%S)] $1" >> "$LOG_FILE"
+}
 
-# Read prompt
+write_log "Starting AI News Briefing..."
+
+# -- CLI Engine Registry ---------------------------------------
+#
+# Each engine needs:
+#   resolve_binary <cli>   -> prints binary path or returns 1
+#   run_engine <cli> <bin> <prompt> -> runs the engine, returns exit code
+#
+# Supported: claude | codex | gemini | copilot
+
+FALLBACK_CHAIN="claude codex gemini copilot"
+
+resolve_binary() {
+  local cli="$1"
+  case "$cli" in
+    claude)
+      for p in "${HOME}/.local/bin/claude" "${HOME}/.local/bin/claude.exe"; do
+        if [ -x "$p" ]; then echo "$p"; return 0; fi
+      done
+      command -v claude 2>/dev/null && return 0
+      return 1
+      ;;
+    codex)
+      command -v codex 2>/dev/null && return 0
+      return 1
+      ;;
+    gemini)
+      command -v gemini 2>/dev/null && return 0
+      return 1
+      ;;
+    copilot)
+      if command -v gh >/dev/null 2>&1; then
+        if gh extension list 2>/dev/null | grep -q copilot; then
+          echo "gh"; return 0
+        fi
+      fi
+      command -v copilot 2>/dev/null && return 0
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+run_engine() {
+  local cli="$1" binary="$2" prompt="$3"
+  local model="${AI_BRIEFING_MODEL:-opus}"
+
+  case "$cli" in
+    claude)
+      "$binary" -p \
+        --model "$model" \
+        --dangerously-skip-permissions \
+        "$prompt" >> "$LOG_FILE" 2>&1
+      ;;
+    codex)
+      "$binary" -q --full-auto \
+        "$prompt" >> "$LOG_FILE" 2>&1
+      ;;
+    gemini)
+      "$binary" -p \
+        "$prompt" >> "$LOG_FILE" 2>&1
+      ;;
+    copilot)
+      if [ "$binary" = "gh" ]; then
+        "$binary" copilot -p \
+          "$prompt" >> "$LOG_FILE" 2>&1
+      else
+        "$binary" -p \
+          "$prompt" >> "$LOG_FILE" 2>&1
+      fi
+      ;;
+  esac
+}
+
+# -- Prompt assembly -------------------------------------------
+if [ ! -f "$SCRIPT_DIR/prompt.md" ]; then
+  write_log "ERROR: prompt.md not found at $SCRIPT_DIR/prompt.md"
+  exit 1
+fi
+
 PROMPT="$(cat "$SCRIPT_DIR/prompt.md")"
 
-# Inject date override if running for a non-today date
 if [[ "$DATE" != "$TODAY" ]]; then
   DATE_PREFIX="BRIEFING DATE OVERRIDE: $DATE
 Generate the briefing for $DATE, NOT today ($TODAY).
@@ -30,50 +158,83 @@ The card.json filename should use $DATE (logs/$DATE-card.json).
 
 "
   PROMPT="${DATE_PREFIX}${PROMPT}"
-  echo "[$DATE $(date +%H:%M:%S)] Date override: generating briefing for $DATE" >> "$LOG_FILE"
+  write_log "Date override: generating briefing for $DATE"
 fi
 
-# Run Claude in print mode with the news prompt
-# --model opus: better adherence to card template constraints
-# --dangerously-skip-permissions: required for headless/automated execution
-# --max-budget-usd: safety cap per run
-"$CLAUDE" -p \
-  --model opus \
-  --dangerously-skip-permissions \
-  "$PROMPT" \
-  >> "$LOG_FILE" 2>&1
+# -- Execution with fallback -----------------------------------
+PREFERRED="${CLI_ARG:-${AI_BRIEFING_CLI:-}}"
+SUCCESS=false
+USED_CLI=""
 
-EXIT_CODE=$?
-TIME=$(date +%H:%M:%S)
+if [ -n "$PREFERRED" ]; then
+  # -- Explicit engine chosen ----------------------------------
+  binary=$(resolve_binary "$PREFERRED" 2>/dev/null) || {
+    write_log "ERROR: Requested engine '$PREFERRED' is not installed."
+    exit 1
+  }
+  write_log "Engine: $PREFERRED ($binary)"
 
-if [ $EXIT_CODE -eq 0 ]; then
-  echo "[$DATE $TIME] Briefing complete. Check Notion for today's report." >> "$LOG_FILE"
+  run_engine "$PREFERRED" "$binary" "$PROMPT"
+  exit_code=$?
 
-  # Post summary to Teams channel if webhook is configured
-  TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
+  if [ $exit_code -eq 0 ]; then
+    SUCCESS=true
+    USED_CLI="$PREFERRED"
+  else
+    write_log "Briefing FAILED with $PREFERRED (exit code $exit_code)."
+  fi
+else
+  # -- Fallback chain ------------------------------------------
+  for cli in $FALLBACK_CHAIN; do
+    binary=$(resolve_binary "$cli" 2>/dev/null) || {
+      write_log "Engine $cli: not found, skipping."
+      continue
+    }
+    write_log "Attempting with $cli ($binary)..."
+
+    run_engine "$cli" "$binary" "$PROMPT"
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+      SUCCESS=true
+      USED_CLI="$cli"
+      break
+    fi
+
+    write_log "$cli failed (exit $exit_code). Trying next engine..."
+  done
+fi
+
+# -- Post-processing -------------------------------------------
+if $SUCCESS; then
+  write_log "Briefing complete. Engine: $USED_CLI. Check Notion for today's report."
+
   CARD_FILE="$LOG_DIR/$DATE-card.json"
+
+  # Teams notification
+  TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
   if [[ -x "$TEAMS_SCRIPT" && -n "${AI_BRIEFING_TEAMS_WEBHOOK:-}" ]]; then
-    echo "[$DATE $(date +%H:%M:%S)] Sending Teams notification..." >> "$LOG_FILE"
+    write_log "Sending Teams notification..."
     if "$TEAMS_SCRIPT" --all --card-file "$CARD_FILE"; then
-      echo "[$DATE $(date +%H:%M:%S)] Teams notification sent." >> "$LOG_FILE"
+      write_log "Teams notification sent."
     else
-      echo "[$DATE $(date +%H:%M:%S)] Teams notification failed." >> "$LOG_FILE"
+      write_log "Teams notification failed."
     fi
   fi
 
-  # Post summary to Slack channel if webhook is configured
+  # Slack notification
   SLACK_SCRIPT="$SCRIPT_DIR/scripts/notify-slack.sh"
   if [[ -x "$SLACK_SCRIPT" && -n "${AI_BRIEFING_SLACK_WEBHOOK:-}" ]]; then
-    echo "[$DATE $(date +%H:%M:%S)] Sending Slack notification..." >> "$LOG_FILE"
+    write_log "Sending Slack notification..."
     if "$SLACK_SCRIPT" --all --card-file "$CARD_FILE"; then
-      echo "[$DATE $(date +%H:%M:%S)] Slack notification sent." >> "$LOG_FILE"
+      write_log "Slack notification sent."
     else
-      echo "[$DATE $(date +%H:%M:%S)] Slack notification failed." >> "$LOG_FILE"
+      write_log "Slack notification failed."
     fi
   fi
 else
-  echo "[$DATE $TIME] Briefing FAILED with exit code $EXIT_CODE." >> "$LOG_FILE"
+  write_log "Briefing FAILED -- all engines exhausted or selected engine failed."
 fi
 
-# Clean up logs older than 30 days
+# -- Cleanup ---------------------------------------------------
 find "$LOG_DIR" -name "*.log" -mtime +30 -delete 2>/dev/null || true

--- a/custom-brief.ps1
+++ b/custom-brief.ps1
@@ -4,11 +4,13 @@
 .SYNOPSIS
     Deep-research a topic and produce a comprehensive news briefing.
 .DESCRIPTION
-    Uses Claude Code in headless mode to conduct multi-agent deep research on a
-    user-defined topic, then optionally publishes to Notion, Teams, and/or Slack.
-    The full briefing is always printed to the terminal.
+    Uses an AI CLI engine in headless mode to conduct multi-agent deep research
+    on a user-defined topic, then optionally publishes to Notion, Teams, and/or Slack.
+    Supports Claude Code, Codex, Gemini, and GitHub Copilot.
 .PARAMETER Topic
     The topic to research. If omitted, enters interactive mode.
+.PARAMETER Cli
+    AI engine: claude, codex, gemini, copilot. Default: AI_BRIEFING_CLI env or claude.
 .PARAMETER Notion
     Publish the briefing to Notion.
 .PARAMETER Teams
@@ -16,7 +18,7 @@
 .PARAMETER Slack
     Send a summary card to Slack.
 .EXAMPLE
-    .\custom-brief.ps1 -Topic "AI in healthcare" -Notion -Teams
+    .\custom-brief.ps1 -Topic "AI in healthcare" -Cli codex -Notion -Teams
 .EXAMPLE
     .\custom-brief.ps1 -Topic "quantum computing" -Notion
 .EXAMPLE
@@ -25,6 +27,8 @@
 
 param(
     [string]$Topic = "",
+    [ValidateSet("claude", "codex", "gemini", "copilot", "")]
+    [string]$Cli = "",
     [switch]$Notion,
     [switch]$Teams,
     [switch]$Slack
@@ -38,32 +42,120 @@ $LogDir = Join-Path $ScriptDir "logs"
 $Date = Get-Date -Format "yyyy-MM-dd"
 $Timestamp = Get-Date -Format "yyyy-MM-dd-HHmmss"
 
-# Resolve Claude CLI path
-$Claude = Join-Path $env:USERPROFILE ".local\bin\claude.exe"
-if (-not (Test-Path $Claude)) {
-    $inPath = Get-Command "claude" -ErrorAction SilentlyContinue
-    if ($inPath) {
-        $Claude = $inPath.Source
-    } else {
-        Write-Error "Claude CLI not found. Install it at $env:USERPROFILE\.local\bin\claude.exe"
-        exit 1
-    }
-}
-
 # Ensure we can run even if Claude Code is open
 $env:CLAUDECODE = $null
 
-# Refresh webhook env vars from registry (parent shell may have stale values)
-$regTeams = [Environment]::GetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "User")
-if ($regTeams) { $env:AI_BRIEFING_TEAMS_WEBHOOK = $regTeams }
-$regSlack = [Environment]::GetEnvironmentVariable("AI_BRIEFING_SLACK_WEBHOOK", "User")
-if ($regSlack) { $env:AI_BRIEFING_SLACK_WEBHOOK = $regSlack }
+# Refresh persistent env vars from registry
+foreach ($name in @("AI_BRIEFING_TEAMS_WEBHOOK", "AI_BRIEFING_SLACK_WEBHOOK", "AI_BRIEFING_CLI", "AI_BRIEFING_MODEL")) {
+    $val = [Environment]::GetEnvironmentVariable($name, "User")
+    if ($val) { [Environment]::SetEnvironmentVariable($name, $val, "Process") }
+}
 
 if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
 }
 
-# -- Banner ------------------------------------------------
+# -- CLI Engine Registry ---------------------------------------
+$SupportedClis = @("claude", "codex", "gemini", "copilot")
+
+function Resolve-CliBinary {
+    param([string]$CliName)
+    switch ($CliName) {
+        "claude" {
+            foreach ($p in @(
+                (Join-Path $env:USERPROFILE ".local\bin\claude.exe"),
+                (Join-Path $env:USERPROFILE ".local\bin\claude")
+            )) {
+                if (Test-Path $p) { return $p }
+            }
+            $cmd = Get-Command "claude" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "codex" {
+            $cmd = Get-Command "codex" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "gemini" {
+            $cmd = Get-Command "gemini" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        "copilot" {
+            $gh = Get-Command "gh" -ErrorAction SilentlyContinue
+            if ($gh) {
+                try {
+                    $exts = & gh extension list 2>$null
+                    if ($exts -match "copilot") { return $gh.Source }
+                } catch {}
+            }
+            $cmd = Get-Command "copilot" -ErrorAction SilentlyContinue
+            if ($cmd) { return $cmd.Source }
+            return $null
+        }
+        default { return $null }
+    }
+}
+
+function Get-CliDisplayName {
+    param([string]$CliName)
+    switch ($CliName) {
+        "claude"  { "Claude Code" }
+        "codex"   { "OpenAI Codex" }
+        "gemini"  { "Gemini CLI" }
+        "copilot" { "GitHub Copilot" }
+        default   { $CliName }
+    }
+}
+
+function Invoke-Engine {
+    param(
+        [string]$CliName,
+        [string]$Binary,
+        [string]$Prompt,
+        [string]$LogPath
+    )
+
+    $model = if ($env:AI_BRIEFING_MODEL) { $env:AI_BRIEFING_MODEL } else { "opus" }
+
+    switch ($CliName) {
+        "claude" {
+            & $Binary -p --model $model --dangerously-skip-permissions $Prompt 2>&1 | ForEach-Object {
+                Write-Host $_
+                $_ | Out-File -FilePath $LogPath -Append -Encoding utf8
+            }
+        }
+        "codex" {
+            & $Binary -q --full-auto $Prompt 2>&1 | ForEach-Object {
+                Write-Host $_
+                $_ | Out-File -FilePath $LogPath -Append -Encoding utf8
+            }
+        }
+        "gemini" {
+            & $Binary -p $Prompt 2>&1 | ForEach-Object {
+                Write-Host $_
+                $_ | Out-File -FilePath $LogPath -Append -Encoding utf8
+            }
+        }
+        "copilot" {
+            if ($Binary -match '[/\\]gh(\.exe)?$') {
+                & $Binary copilot -p $Prompt 2>&1 | ForEach-Object {
+                    Write-Host $_
+                    $_ | Out-File -FilePath $LogPath -Append -Encoding utf8
+                }
+            } else {
+                & $Binary -p $Prompt 2>&1 | ForEach-Object {
+                    Write-Host $_
+                    $_ | Out-File -FilePath $LogPath -Append -Encoding utf8
+                }
+            }
+        }
+    }
+    return $(if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 })
+}
+
+# -- Banner ----------------------------------------------------
 function Write-Banner {
     $d = "DarkGray"
     $c = "Cyan"
@@ -80,20 +172,79 @@ function Write-Banner {
     Write-Host "  (_____)---------------------------------------------------------------(_____)  " -ForegroundColor $d
 }
 
-# -- Interactive REPL (if no topic provided) ---------------
+# -- Interactive REPL (if no topic provided) -------------------
 if (-not $Topic) {
     Write-Banner
     Write-Host ""
     Write-Host "  Interactive Mode" -ForegroundColor Magenta
     Write-Host ""
-    Write-Host "  Topic: " -NoNewline
+
+    # Topic
+    Write-Host "  --- Topic -------------------------------------------------" -ForegroundColor DarkGray
+    Write-Host "  What would you like to research?"
+    Write-Host "  > " -NoNewline
     $Topic = Read-Host
     if (-not $Topic) {
         Write-Host "  Error: topic cannot be empty." -ForegroundColor Red
         exit 1
     }
     Write-Host ""
-    Write-Host "  Publish to:" -ForegroundColor DarkGray
+
+    # AI Engine
+    Write-Host "  --- AI Engine ---------------------------------------------" -ForegroundColor DarkGray
+    $idx = 0
+    $defaultIdx = 0
+    $defaultCli = ""
+    foreach ($c in $SupportedClis) {
+        $idx++
+        $label = Get-CliDisplayName $c
+        $padded = $label.PadRight(16)
+        $binary = Resolve-CliBinary -CliName $c
+        if ($binary) {
+            Write-Host "    " -NoNewline
+            Write-Host "$idx)" -ForegroundColor White -NoNewline
+            Write-Host " $padded " -NoNewline
+            Write-Host "available" -ForegroundColor Green
+            if (-not $defaultCli) {
+                $defaultCli = $c
+                $defaultIdx = $idx
+            }
+        } else {
+            Write-Host "    " -NoNewline
+            Write-Host "$idx)" -ForegroundColor White -NoNewline
+            Write-Host " $padded " -NoNewline
+            Write-Host "not installed" -ForegroundColor Red
+        }
+    }
+    Write-Host ""
+
+    # Check env var for default
+    $envCli = $env:AI_BRIEFING_CLI
+    if ($envCli) {
+        $idx = 0
+        foreach ($c in $SupportedClis) {
+            $idx++
+            if ($c -eq $envCli) { $defaultIdx = $idx; $defaultCli = $envCli; break }
+        }
+    }
+
+    Write-Host "  Select [1-4, default=$defaultIdx]: " -NoNewline
+    $engineChoice = Read-Host
+    if (-not $engineChoice) {
+        $Cli = $defaultCli
+    } else {
+        $choiceInt = [int]$engineChoice
+        if ($choiceInt -ge 1 -and $choiceInt -le $SupportedClis.Count) {
+            $Cli = $SupportedClis[$choiceInt - 1]
+        } else {
+            Write-Host "  Invalid selection." -ForegroundColor Red
+            exit 1
+        }
+    }
+    Write-Host ""
+
+    # Publish destinations
+    Write-Host "  --- Publish -----------------------------------------------" -ForegroundColor DarkGray
     $yn = Read-Host "    Notion? [y/N]"
     if ($yn -match "^[Yy]") { $Notion = [switch]::new($true) }
     $yn = Read-Host "    Teams?  [y/N]"
@@ -103,18 +254,30 @@ if (-not $Topic) {
     Write-Host ""
 }
 
-# -- Derive flags ------------------------------------------
+# -- Resolve engine (non-interactive fallback) -----------------
+if (-not $Cli) {
+    $Cli = if ($env:AI_BRIEFING_CLI) { $env:AI_BRIEFING_CLI } else { "claude" }
+}
+
+$EngineBinary = Resolve-CliBinary -CliName $Cli
+if (-not $EngineBinary) {
+    Write-Host "  ERROR" -ForegroundColor Red -NoNewline
+    Write-Host "  Engine '$(Get-CliDisplayName $Cli)' is not installed." -ForegroundColor Red
+    exit 1
+}
+
+# -- Derive flags ----------------------------------------------
 $PublishNotion = if ($Notion) { "true" } else { "false" }
 $PublishTeamsSlack = if ($Teams -or $Slack) { "true" } else { "false" }
+$PublishTeams = if ($Teams) { "true" } else { "false" }
+$PublishSlack = if ($Slack) { "true" } else { "false" }
 
 $LogFile = Join-Path $LogDir "custom-$Timestamp.log"
 $CardFile = Join-Path $LogDir "custom-$Timestamp-card.json"
 
-# -- Build the prompt --------------------------------------
+# -- Build the prompt ------------------------------------------
 $PromptTemplate = Get-Content -Path (Join-Path $ScriptDir "prompt-custom-brief.md") -Raw
 
-# Use [string]::Replace() for literal substitution -- avoids regex
-# backreference issues when topic contains $1, $0, etc.
 $Prompt = $PromptTemplate.
     Replace('{{TOPIC}}', $Topic).
     Replace('{{DATE}}', $Date).
@@ -122,15 +285,10 @@ $Prompt = $PromptTemplate.
     Replace('{{PUBLISH_NOTION}}', $PublishNotion).
     Replace('{{PUBLISH_TEAMS_SLACK}}', $PublishTeamsSlack)
 
-# -- Derive Teams/Slack booleans for display ---------------
-$PublishTeams = if ($Teams) { "true" } else { "false" }
-$PublishSlack = if ($Slack) { "true" } else { "false" }
-
-# -- Styled boolean label ---------------------------------
+# -- Styled boolean label --------------------------------------
 function Write-Flag {
     param([string]$Label, [string]$Value)
     Write-Host "  $Label" -NoNewline
-    # Pad to align
     Write-Host (" " * (10 - $Label.Length)) -NoNewline
     if ($Value -eq "true") {
         Write-Host "yes" -ForegroundColor Green
@@ -139,26 +297,25 @@ function Write-Flag {
     }
 }
 
-# -- Print run summary ------------------------------------
+# -- Print run summary -----------------------------------------
 Write-Banner
 Write-Host ""
 Write-Host "  Deep Research" -ForegroundColor Magenta
 Write-Host ""
-Write-Host "  Topic     " -NoNewline
-Write-Host "$Topic"
+Write-Host "  Topic     " -NoNewline; Write-Host "$Topic"
+Write-Host "  Engine    " -NoNewline; Write-Host "$(Get-CliDisplayName $Cli)" -NoNewline; Write-Host " ($EngineBinary)" -ForegroundColor DarkGray
 Write-Flag "Notion" $PublishNotion
 Write-Flag "Teams" $PublishTeams
 Write-Flag "Slack" $PublishSlack
-Write-Host "  Log       " -NoNewline -ForegroundColor DarkGray
-Write-Host "$LogFile" -ForegroundColor DarkGray
+Write-Host "  Log       " -NoNewline -ForegroundColor DarkGray; Write-Host "$LogFile" -ForegroundColor DarkGray
 Write-Host ""
-Write-Host "  Launching 5 parallel research agents..." -ForegroundColor Magenta
+Write-Host "  Launching research agents via $(Get-CliDisplayName $Cli)..." -ForegroundColor Magenta
 Write-Host "  This may take a few minutes." -ForegroundColor DarkGray
 Write-Host ""
 Write-Host "  ================================================" -ForegroundColor DarkGray
 Write-Host ""
 
-# -- Log header --------------------------------------------
+# -- Log header ------------------------------------------------
 function Write-Log {
     param([string]$Message)
     $ts = Get-Date -Format "HH:mm:ss"
@@ -166,21 +323,11 @@ function Write-Log {
 }
 
 Write-Log "Custom Brief -- Topic: $Topic"
-Write-Log "Notion=$PublishNotion Teams=$PublishTeams Slack=$PublishSlack"
+Write-Log "Engine=$Cli Notion=$PublishNotion Teams=$PublishTeams Slack=$PublishSlack"
 
-# -- Run Claude --------------------------------------------
+# -- Run engine ------------------------------------------------
 try {
-    # Stream Claude output line-by-line to both console and log in real time.
-    # Do NOT buffer into a variable -- that hides the briefing until Claude finishes.
-    & $Claude -p `
-        --model opus `
-        --dangerously-skip-permissions `
-        $Prompt 2>&1 | ForEach-Object {
-            Write-Host $_
-            $_ | Out-File -FilePath $LogFile -Append -Encoding utf8
-        }
-
-    $exitCode = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 }
+    $exitCode = Invoke-Engine -CliName $Cli -Binary $EngineBinary -Prompt $Prompt -LogPath $LogFile
 
     if ($exitCode -ne 0) {
         Write-Log "Custom brief FAILED with exit code $exitCode."
@@ -193,7 +340,7 @@ try {
 
     Write-Log "Custom brief complete."
 
-    # -- Post-processing: Teams notification ---------------
+    # -- Post-processing: Teams notification -------------------
     if ($Teams) {
         $teamsScript = Join-Path $ScriptDir "scripts\notify-teams.ps1"
         if ((Test-Path $teamsScript) -and $env:AI_BRIEFING_TEAMS_WEBHOOK) {
@@ -224,7 +371,7 @@ try {
         }
     }
 
-    # -- Post-processing: Slack notification ---------------
+    # -- Post-processing: Slack notification -------------------
     if ($Slack) {
         $slackScript = Join-Path $ScriptDir "scripts\notify-slack.ps1"
         if ((Test-Path $slackScript) -and $env:AI_BRIEFING_SLACK_WEBHOOK) {

--- a/custom-brief.sh
+++ b/custom-brief.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
@@ -14,8 +14,7 @@ elif [ -x "${HOME}/.local/bin/claude.exe" ]; then
 elif command -v claude >/dev/null 2>&1; then
   CLAUDE="$(command -v claude)"
 else
-  echo "ERROR: Claude CLI not found. Install it at ~/.local/bin/claude" >&2
-  exit 1
+  CLAUDE=""
 fi
 
 # Ensure we can run even if Claude Code is open
@@ -23,7 +22,7 @@ unset CLAUDECODE 2>/dev/null || true
 
 mkdir -p "$LOG_DIR"
 
-# -- Colors (auto-disable if not a terminal) ---------------
+# -- Colors (auto-disable if not a terminal) -------------------
 if [[ -t 1 ]]; then
   BOLD='\033[1m'
   DIM='\033[2m'
@@ -32,18 +31,95 @@ if [[ -t 1 ]]; then
   YELLOW='\033[33m'
   RED='\033[31m'
   MAGENTA='\033[35m'
+  WHITE='\033[97m'
   RESET='\033[0m'
 else
-  BOLD='' DIM='' CYAN='' GREEN='' YELLOW='' RED='' MAGENTA='' RESET=''
+  BOLD='' DIM='' CYAN='' GREEN='' YELLOW='' RED='' MAGENTA='' WHITE='' RESET=''
 fi
 
-# -- Defaults ----------------------------------------------
+# -- CLI Engine Registry ---------------------------------------
+SUPPORTED_CLIS="claude codex gemini copilot"
+
+resolve_binary() {
+  local cli="$1"
+  case "$cli" in
+    claude)
+      for p in "${HOME}/.local/bin/claude" "${HOME}/.local/bin/claude.exe"; do
+        if [ -x "$p" ]; then echo "$p"; return 0; fi
+      done
+      command -v claude 2>/dev/null && return 0
+      return 1
+      ;;
+    codex)
+      command -v codex 2>/dev/null && return 0
+      return 1
+      ;;
+    gemini)
+      command -v gemini 2>/dev/null && return 0
+      return 1
+      ;;
+    copilot)
+      if command -v gh >/dev/null 2>&1; then
+        if gh extension list 2>/dev/null | grep -q copilot; then
+          echo "gh"; return 0
+        fi
+      fi
+      command -v copilot 2>/dev/null && return 0
+      return 1
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+cli_display_name() {
+  case "$1" in
+    claude)  echo "Claude Code" ;;
+    codex)   echo "OpenAI Codex" ;;
+    gemini)  echo "Gemini CLI" ;;
+    copilot) echo "GitHub Copilot" ;;
+    *)       echo "$1" ;;
+  esac
+}
+
+run_engine() {
+  local cli="$1" binary="$2" prompt="$3" log="$4"
+  local model="${AI_BRIEFING_MODEL:-opus}"
+
+  case "$cli" in
+    claude)
+      "$binary" -p \
+        --model "$model" \
+        --dangerously-skip-permissions \
+        "$prompt" 2>&1 | tee -a "$log"
+      ;;
+    codex)
+      "$binary" -q --full-auto \
+        "$prompt" 2>&1 | tee -a "$log"
+      ;;
+    gemini)
+      "$binary" -p \
+        "$prompt" 2>&1 | tee -a "$log"
+      ;;
+    copilot)
+      if [ "$binary" = "gh" ]; then
+        "$binary" copilot -p \
+          "$prompt" 2>&1 | tee -a "$log"
+      else
+        "$binary" -p \
+          "$prompt" 2>&1 | tee -a "$log"
+      fi
+      ;;
+  esac
+}
+
+# -- Defaults --------------------------------------------------
 TOPIC=""
+CLI_ENGINE=""
 PUBLISH_NOTION=false
 PUBLISH_TEAMS=false
 PUBLISH_SLACK=false
 
-# -- Parse arguments ---------------------------------------
+# -- Parse arguments -------------------------------------------
 print_usage() {
   cat <<'EOF'
 Usage: custom-brief.sh [OPTIONS]
@@ -51,17 +127,22 @@ Usage: custom-brief.sh [OPTIONS]
 Deep-research a topic and produce a comprehensive news briefing.
 
 Options:
-  --topic, -t TEXT    Topic to research (required in non-interactive mode)
-  --notion, -n        Publish to Notion
-  --teams             Publish to Microsoft Teams
-  --slack             Publish to Slack
-  --help, -h          Show this help
+  --topic, -t TEXT        Topic to research (required in non-interactive mode)
+  --cli, -c ENGINE        AI engine: claude, codex, gemini, copilot
+  --notion, -n            Publish to Notion
+  --teams                 Publish to Microsoft Teams
+  --slack                 Publish to Slack
+  --help, -h              Show this help
+
+Environment:
+  AI_BRIEFING_CLI         Default engine (overridden by --cli)
+  AI_BRIEFING_MODEL       Model name (default: opus)
 
 If no arguments are given, enters interactive mode.
 
 Examples:
-  ./custom-brief.sh --topic "AI in healthcare" --notion --teams
-  ./custom-brief.sh -t "quantum computing" -n
+  ./custom-brief.sh --topic "AI in healthcare" --cli codex --notion --teams
+  ./custom-brief.sh -t "quantum computing" -c gemini -n
   ./custom-brief.sh   # interactive mode
 EOF
 }
@@ -69,36 +150,26 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --topic|-t)
-      if [[ $# -lt 2 ]]; then echo "ERROR: --topic requires a value" >&2; exit 1; fi
-      TOPIC="$2"
-      shift 2
-      ;;
+      [[ $# -lt 2 ]] && { echo "ERROR: --topic requires a value" >&2; exit 1; }
+      TOPIC="$2"; shift 2 ;;
+    --cli|-c)
+      [[ $# -lt 2 ]] && { echo "ERROR: --cli requires a value" >&2; exit 1; }
+      CLI_ENGINE="$2"; shift 2 ;;
     --notion|-n)
-      PUBLISH_NOTION=true
-      shift
-      ;;
+      PUBLISH_NOTION=true; shift ;;
     --teams)
-      PUBLISH_TEAMS=true
-      shift
-      ;;
+      PUBLISH_TEAMS=true; shift ;;
     --slack)
-      PUBLISH_SLACK=true
-      shift
-      ;;
+      PUBLISH_SLACK=true; shift ;;
     --help|-h)
-      print_usage
-      exit 0
-      ;;
+      print_usage; exit 0 ;;
     *)
-      echo "Unknown option: $1" >&2
-      print_usage
-      exit 1
-      ;;
+      echo "Unknown option: $1" >&2; print_usage; exit 1 ;;
   esac
 done
 
-# -- Interactive REPL (if no topic provided) ---------------
-if [[ -z "$TOPIC" ]]; then
+# -- Banner ----------------------------------------------------
+print_banner() {
   echo ""
   echo -e "  ${DIM} _____                                                                 _____ ${RESET}"
   echo -e "  ${DIM}( ___ )---------------------------------------------------------------( ___ )${RESET}"
@@ -111,16 +182,76 @@ if [[ -z "$TOPIC" ]]; then
   echo -e "  ${DIM} |___|                                                                 |___| ${RESET}"
   echo -e "  ${DIM}(_____)---------------------------------------------------------------(_____)${RESET}"
   echo ""
-  echo -e "  ${MAGENTA}Interactive Mode${RESET}"
+}
+
+# -- Interactive REPL (if no topic provided) -------------------
+if [[ -z "$TOPIC" ]]; then
+  print_banner
+  echo -e "  ${MAGENTA}${BOLD}Interactive Mode${RESET}"
   echo ""
-  echo -ne "  ${BOLD}Topic:${RESET} "
+
+  # Topic
+  echo -e "  ${DIM}--- Topic -------------------------------------------------${RESET}"
+  echo -ne "  ${BOLD}What would you like to research?${RESET}\n  > "
   read -r TOPIC
   if [[ -z "$TOPIC" ]]; then
     echo -e "  ${RED}Error: topic cannot be empty.${RESET}" >&2
     exit 1
   fi
   echo ""
-  echo -e "  ${DIM}Publish to:${RESET}"
+
+  # AI Engine
+  echo -e "  ${DIM}--- AI Engine ---------------------------------------------${RESET}"
+  idx=0
+  default_idx=0
+  default_cli=""
+  for cli in $SUPPORTED_CLIS; do
+    idx=$((idx + 1))
+    label="$(cli_display_name "$cli")"
+    # Pad label to fixed width
+    padded="$(printf '%-16s' "$label")"
+    if resolve_binary "$cli" >/dev/null 2>&1; then
+      avail="${GREEN}available${RESET}"
+      if [[ -z "$default_cli" ]]; then
+        default_cli="$cli"
+        default_idx=$idx
+      fi
+    else
+      avail="${RED}not installed${RESET}"
+    fi
+    echo -e "    ${WHITE}${idx})${RESET} ${padded} ${avail}"
+  done
+  echo ""
+
+  env_cli="${AI_BRIEFING_CLI:-}"
+  if [[ -n "$env_cli" ]]; then
+    # Find index of env-configured CLI
+    idx=0
+    for cli in $SUPPORTED_CLIS; do
+      idx=$((idx + 1))
+      if [[ "$cli" == "$env_cli" ]]; then default_idx=$idx; default_cli="$env_cli"; break; fi
+    done
+  fi
+
+  echo -ne "  ${BOLD}Select [1-4, default=${default_idx}]:${RESET} "
+  read -r engine_choice
+  if [[ -z "$engine_choice" ]]; then
+    CLI_ENGINE="$default_cli"
+  else
+    idx=0
+    for cli in $SUPPORTED_CLIS; do
+      idx=$((idx + 1))
+      if [[ "$idx" == "$engine_choice" ]]; then CLI_ENGINE="$cli"; break; fi
+    done
+    if [[ -z "$CLI_ENGINE" ]]; then
+      echo -e "  ${RED}Invalid selection.${RESET}" >&2
+      exit 1
+    fi
+  fi
+  echo ""
+
+  # Publish destinations
+  echo -e "  ${DIM}--- Publish -----------------------------------------------${RESET}"
   read -rp "    Notion? [y/N]: " yn
   [[ "$yn" =~ ^[Yy] ]] && PUBLISH_NOTION=true
   read -rp "    Teams?  [y/N]: " yn
@@ -130,21 +261,28 @@ if [[ -z "$TOPIC" ]]; then
   echo ""
 fi
 
-# -- Determine if card JSON is needed ----------------------
+# -- Resolve engine (non-interactive fallback) -----------------
+if [[ -z "$CLI_ENGINE" ]]; then
+  CLI_ENGINE="${AI_BRIEFING_CLI:-claude}"
+fi
+
+ENGINE_BINARY=$(resolve_binary "$CLI_ENGINE" 2>/dev/null) || {
+  echo -e "  ${RED}${BOLD}ERROR${RESET}  ${RED}Engine '$(cli_display_name "$CLI_ENGINE")' is not installed.${RESET}" >&2
+  exit 1
+}
+
+# -- Determine if card JSON is needed --------------------------
 PUBLISH_TEAMS_SLACK=false
 if [[ "$PUBLISH_TEAMS" == "true" || "$PUBLISH_SLACK" == "true" ]]; then
   PUBLISH_TEAMS_SLACK=true
 fi
 
-# -- Build the prompt --------------------------------------
+# -- Build the prompt ------------------------------------------
 LOG_FILE="$LOG_DIR/custom-$TIMESTAMP.log"
 CARD_FILE="$LOG_DIR/custom-$TIMESTAMP-card.json"
 
 PROMPT_TEMPLATE="$(cat "$SCRIPT_DIR/prompt-custom-brief.md")"
 
-# Replace placeholders using awk for safe literal substitution.
-# Bash parameter expansion treats & and \ specially in replacements,
-# so awk gsub is safer for user-supplied topic strings.
 PROMPT="$(awk \
   -v topic="$TOPIC" \
   -v date="$DATE" \
@@ -160,7 +298,7 @@ PROMPT="$(awk \
     print
   }' <<< "$PROMPT_TEMPLATE")"
 
-# -- Helpers for styled boolean display --------------------
+# -- Helpers for styled boolean display ------------------------
 flag_label() {
   if [[ "$1" == "true" ]]; then
     echo -e "${GREEN}yes${RESET}"
@@ -169,49 +307,33 @@ flag_label() {
   fi
 }
 
-# -- Print run summary ------------------------------------
-echo ""
-echo -e "  ${DIM} _____                                                                 _____ ${RESET}"
-echo -e "  ${DIM}( ___ )---------------------------------------------------------------( ___ )${RESET}"
-echo -e "  ${DIM} |   |                                                                 |   | ${RESET}"
-echo -e "  ${DIM} |   |${RESET}${BOLD}${CYAN}     _    ___   _   _                     ____       _       __  ${RESET}${DIM}|   | ${RESET}"
-echo -e "  ${DIM} |   |${RESET}${BOLD}${CYAN}    / \\  |_ _| | \\ | | _____      _____  | __ ) _ __(_) ___ / _| ${RESET}${DIM}|   | ${RESET}"
-echo -e "  ${DIM} |   |${RESET}${BOLD}${CYAN}   / _ \\  | |  |  \\| |/ _ \\ \\ /\\ / / __| |  _ \\| '__| |/ _ \\ |_  ${RESET}${DIM}|   | ${RESET}"
-echo -e "  ${DIM} |   |${RESET}${BOLD}${CYAN}  / ___ \\ | |  | |\\  |  __/\\ V  V /\\__ \\ | |_) | |  | |  __/  _| ${RESET}${DIM}|   | ${RESET}"
-echo -e "  ${DIM} |   |${RESET}${BOLD}${CYAN} /_/   \\_\\___| |_| \\_|\\___| \\_/\\_/ |___/ |____/|_|  |_|\\___|_|   ${RESET}${DIM}|   | ${RESET}"
-echo -e "  ${DIM} |___|                                                                 |___| ${RESET}"
-echo -e "  ${DIM}(_____)---------------------------------------------------------------(_____)${RESET}"
-echo ""
-echo -e "  ${MAGENTA}Deep Research${RESET}"
+# -- Print run summary -----------------------------------------
+print_banner
+echo -e "  ${MAGENTA}${BOLD}Deep Research${RESET}"
 echo ""
 echo -e "  ${BOLD}Topic${RESET}     $TOPIC"
+echo -e "  ${BOLD}Engine${RESET}    $(cli_display_name "$CLI_ENGINE") ${DIM}($ENGINE_BINARY)${RESET}"
 echo -e "  ${BOLD}Notion${RESET}    $(flag_label "$PUBLISH_NOTION")"
 echo -e "  ${BOLD}Teams${RESET}     $(flag_label "$PUBLISH_TEAMS")"
 echo -e "  ${BOLD}Slack${RESET}     $(flag_label "$PUBLISH_SLACK")"
 echo -e "  ${DIM}Log${RESET}       ${DIM}$LOG_FILE${RESET}"
 echo ""
-echo -e "  ${MAGENTA}Launching 5 parallel research agents...${RESET}"
+echo -e "  ${MAGENTA}Launching research agents via $(cli_display_name "$CLI_ENGINE")...${RESET}"
 echo -e "  ${DIM}This may take a few minutes.${RESET}"
 echo ""
 echo -e "  ${DIM}================================================${RESET}"
 echo ""
 
-# -- Log header --------------------------------------------
+# -- Log header ------------------------------------------------
 {
   echo "[$DATE $(date +%H:%M:%S)] Custom Brief -- Topic: $TOPIC"
-  echo "[$DATE $(date +%H:%M:%S)] Notion=$PUBLISH_NOTION Teams=$PUBLISH_TEAMS Slack=$PUBLISH_SLACK"
+  echo "[$DATE $(date +%H:%M:%S)] Engine=$CLI_ENGINE Notion=$PUBLISH_NOTION Teams=$PUBLISH_TEAMS Slack=$PUBLISH_SLACK"
 } >> "$LOG_FILE"
 
-# -- Run Claude --------------------------------------------
-# Tee to both stdout (user sees briefing) and log file.
-# Temporarily disable pipefail so tee doesn't mask Claude's exit code,
-# then capture Claude's exit code via PIPESTATUS[0].
+# -- Run engine ------------------------------------------------
 set +o pipefail
-"$CLAUDE" -p \
-    --model opus \
-    --dangerously-skip-permissions \
-    "$PROMPT" 2>&1 | tee -a "$LOG_FILE"
-EXIT_CODE="${PIPESTATUS[0]}"
+run_engine "$CLI_ENGINE" "$ENGINE_BINARY" "$PROMPT" "$LOG_FILE"
+EXIT_CODE="${PIPESTATUS[0]:-$?}"
 set -o pipefail
 
 echo "" >> "$LOG_FILE"
@@ -226,7 +348,7 @@ fi
 
 echo "[$DATE $(date +%H:%M:%S)] Custom brief complete." >> "$LOG_FILE"
 
-# -- Post-processing: Teams notification -------------------
+# -- Post-processing: Teams notification -----------------------
 if [[ "$PUBLISH_TEAMS" == "true" ]]; then
   TEAMS_SCRIPT="$SCRIPT_DIR/scripts/notify-teams.sh"
   if [[ -f "$TEAMS_SCRIPT" && -n "${AI_BRIEFING_TEAMS_WEBHOOK:-}" ]]; then
@@ -250,7 +372,7 @@ if [[ "$PUBLISH_TEAMS" == "true" ]]; then
   fi
 fi
 
-# -- Post-processing: Slack notification -------------------
+# -- Post-processing: Slack notification -----------------------
 if [[ "$PUBLISH_SLACK" == "true" ]]; then
   SLACK_SCRIPT="$SCRIPT_DIR/scripts/notify-slack.sh"
   if [[ -f "$SLACK_SCRIPT" && -n "${AI_BRIEFING_SLACK_WEBHOOK:-}" ]]; then

--- a/tests/test-daily-brief.sh
+++ b/tests/test-daily-brief.sh
@@ -79,7 +79,7 @@ assert_contains "$skill" "covered-stories.txt" "skill: references dedup file"
 # -- Entry script structure (briefing.sh) ------------------
 section "Entry script (briefing.sh)"
 entry=$(cat "$SCRIPT_DIR/briefing.sh")
-assert_contains "$entry" "set -e" "briefing.sh: uses strict mode"
+assert_contains "$entry" "fallback" "briefing.sh: uses fallback chain (explicit error handling)"
 assert_contains "$entry" "prompt.md" "briefing.sh: reads prompt.md"
 assert_contains "$entry" "claude" "briefing.sh: invokes Claude CLI"
 assert_contains "$entry" "notify-teams" "briefing.sh: calls Teams notifier"


### PR DESCRIPTION
Add support for 4 AI CLI engines: Claude Code, Codex, Gemini, and Copilot. Daily briefing auto-falls back (claude -> codex -> gemini -> copilot) if the preferred engine fails. Custom brief REPL shows engine availability and lets users pick interactively, or use --cli flag.

Scripts rewritten:
- briefing.sh / briefing.ps1: arg parsing, CLI registry, fallback chain
- custom-brief.sh / custom-brief.ps1: --cli flag, engine picker REPL

Makefile updated:
- run/custom-brief targets accept CLI= parameter
- check target verifies any installed CLI
- info target shows all installed engines

Env vars:
- AI_BRIEFING_CLI: lock to specific engine (skip fallback)
- AI_BRIEFING_MODEL: override default model

Documentation updated:
- README, ARCHITECTURE, SETUP, CUSTOM_BRIEF: multi-engine references

Tests: 247 passing (156 bash + 91 PowerShell)