### PR TITLE
feat: integrate Obsidian publishing for briefings with topic stubs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 ![GitHub Copilot CLI](https://img.shields.io/badge/GitHub_Copilot-CLI-238636?logo=githubcopilot&logoColor=white)
 ![WebSearch Tool](https://img.shields.io/badge/WebSearch_Tool-Integrated-10b981?logo=claude&logoColor=white)
 ![Notion](https://img.shields.io/badge/Notion-MCP-000000?logo=notion&logoColor=white)
+![Obsidian](https://img.shields.io/badge/Obsidian-Graph_View-7C3AED?logo=obsidian&logoColor=white)
 ![MCP](https://img.shields.io/badge/Model_Context_Protocol-1.0-10b981?logo=modelcontextprotocol&logoColor=white)
 ![Adaptive Cards](https://img.shields.io/badge/Adaptive_Cards-v1.4-0078D4?logo=json&logoColor=white)
 ![Bash](https://img.shields.io/badge/Bash-Script-4EAA25?logo=gnubash&logoColor=white)
@@ -20,13 +21,13 @@
 ![Slack](https://img.shields.io/badge/Slack-Webhook-4A154B?logo=slack&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)
-![Tests](https://img.shields.io/badge/Shell_Tests-247_Passing-10b981?logo=checkmarx&logoColor=white)
+![Tests](https://img.shields.io/badge/Shell_Tests-201_Passing-10b981?logo=checkmarx&logoColor=white)
 ![ANSI Colors](https://img.shields.io/badge/CLI-Styled_Output-ff6b6b?logo=windowsterminal&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-Version_Control-F05032?logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-This document describes the architecture, data flow, and design decisions behind the AI News Briefing system -- an automated daily AI news aggregation pipeline that uses one of four supported AI CLI engines (Claude Code, Codex, Gemini, Copilot) to search the web, compile a structured briefing, and publish it to Notion.
+This document describes the architecture, data flow, and design decisions behind the AI News Briefing system -- an automated daily AI news aggregation pipeline that uses one of four supported AI CLI engines (Claude Code, Codex, Gemini, Copilot) to search the web, compile a structured briefing, and publish it to Notion and/or Obsidian.
 
 The system is cross-platform, supporting macOS (launchd) and Windows (Task Scheduler).
 
@@ -78,6 +79,7 @@ graph TD
         D -->|Notion MCP tool| F[Notion API]
         F --> G[Notion Page - AI Daily Briefing]
         D -->|Writes| CJ["logs/YYYY-MM-DD-card.json"]
+        D -->|Writes| OJ["logs/YYYY-MM-DD-obsidian.md"]
     end
 
     subgraph "Post-Processing"
@@ -91,6 +93,11 @@ graph TD
         S1 -->|Converts & POSTs| CJ
         S2 -->|Converts & POSTs| CJ
         CJ -->|Block Kit JSON| SW[Slack Webhook]
+        B1 -->|On success| OB1[publish-obsidian.sh]
+        B2 -->|On success| OB2[publish-obsidian.ps1]
+        OB1 -->|Copy + topic stubs| OJ
+        OB2 -->|Copy + topic stubs| OJ
+        OJ -->|Graph-ready markdown| OBV["Obsidian Vault"]
     end
 
     B1 -->|Writes logs| H[logs/ Directory]
@@ -586,8 +593,11 @@ flowchart TD
         SYNTH -->|Always| STDOUT[Terminal output]
         SYNTH -->|If --notion| NOTION[Notion page]
         SYNTH -->|If --teams/--slack| CARD[Card JSON]
+        SYNTH -->|If --obsidian| OBS["Obsidian markdown<br/>with [[wikilinks]]"]
         CARD --> NT["notify-teams.sh/.ps1"]
         CARD --> NS["notify-slack.sh/.ps1"]
+        OBS --> OP["publish-obsidian.sh/.ps1"]
+        OP --> VAULT["Obsidian Vault<br/>+ Topic Stubs"]
     end
 ```
 
@@ -611,12 +621,13 @@ Each of the 5 agents receives a targeted search brief and returns findings with 
 
 | File | Purpose |
 |------|---------|
-| `custom-brief.sh` | Bash CLI with `--topic`, `--notion`, `--teams`, `--slack` params + REPL mode |
-| `custom-brief.ps1` | PowerShell CLI with equivalent `-Topic`, `-Notion`, `-Teams`, `-Slack` params |
+| `custom-brief.sh` | Bash CLI with `--topic`, `--notion`, `--teams`, `--slack`, `--obsidian` params + REPL mode |
+| `custom-brief.ps1` | PowerShell CLI with equivalent `-Topic`, `-Notion`, `-Teams`, `-Slack`, `-Obsidian` params |
 | `prompt-custom-brief.md` | Prompt template with `{{TOPIC}}`, `{{DATE}}`, `{{PUBLISH_*}}` placeholders |
 | `commands/custom-brief.md` | Claude Code skill for interactive sessions |
 | `logs/custom-TIMESTAMP.log` | Execution log |
 | `logs/custom-TIMESTAMP-card.json` | Adaptive Card JSON (if Teams/Slack requested) |
+| `logs/custom-TIMESTAMP-obsidian.md` | Obsidian markdown with wikilinks (if Obsidian requested) |
 
 #### Prompt Template Variable Injection
 
@@ -625,7 +636,7 @@ The CLI scripts perform string replacement on `prompt-custom-brief.md` before pa
 ```mermaid
 flowchart LR
     T["--topic arg"] --> S["custom-brief.sh/.ps1"]
-    F["--notion/--teams/--slack"] --> S
+    F["--notion/--teams/--slack/--obsidian"] --> S
     S -->|"Replace {{TOPIC}}"| P["prompt-custom-brief.md"]
     S -->|"Replace {{DATE}}"| P
     S -->|"Replace {{PUBLISH_*}}"| P
@@ -641,24 +652,116 @@ The custom brief reuses the same infrastructure:
 | Notion database | Same (data_source_id) | Same |
 | Teams notification | `notify-teams.sh/.ps1` | Same scripts |
 | Slack notification | `notify-slack.sh/.ps1` + `teams-to-slack.py` | Same scripts |
+| Obsidian publishing | `publish-obsidian.sh/.ps1` | Same scripts |
 | Card template | Adaptive Card v1.4 | Same structure, different header |
 | Page title | `YYYY-MM-DD - AI Daily Briefing` | `YYYY-MM-DD - Custom Brief: [Topic]` |
+| Obsidian file | `logs/YYYY-MM-DD-obsidian.md` | `logs/custom-TIMESTAMP-obsidian.md` |
 | Log naming | `logs/YYYY-MM-DD.log` | `logs/custom-YYYY-MM-DD-HHMMSS.log` |
 | Deduplication | Yes (covered-stories.txt) | No (standalone) |
 
-### 3.12 Test Suite
+### 3.12 Obsidian Publishing Pipeline
 
-247 non-blocking tests across bash and PowerShell verify the entire system without calling external services. Tests cover syntax, structure, argument handling, template substitution, card JSON validation, notification error paths, and cross-platform portability.
+Obsidian is a local-first knowledge base that stores notes as plain markdown files in a "vault" directory. Unlike Notion (which requires an API), Obsidian integration works by writing `.md` files directly to the file system. Obsidian's graph view automatically visualizes connections between notes via `[[wikilinks]]`.
+
+#### Architecture Overview
+
+```mermaid
+flowchart TD
+    subgraph "Claude Code Output"
+        CB["Claude writes<br/>logs/*-obsidian.md"]
+    end
+
+    subgraph "Post-Processing"
+        CB --> PB["publish-obsidian.sh/.ps1"]
+        PB -->|"Copy to vault"| VB["AI-News-Briefings/"]
+        PB -->|"Extract [[wikilinks]]"| TS["Create topic stubs"]
+        TS --> VT["Topics/"]
+    end
+
+    subgraph "Obsidian Vault"
+        VB --> B1["2026-04-11 - AI Daily Briefing.md"]
+        VB --> B2["2026-04-11 - Custom Brief - Claude Code.md"]
+        VT --> T1["Claude Code.md"]
+        VT --> T2["OpenAI.md"]
+        VT --> T3["AI Coding IDEs.md"]
+    end
+
+    subgraph "Graph View"
+        B1 -.->|"[[Claude Code]]"| T1
+        B1 -.->|"[[OpenAI]]"| T2
+        B2 -.->|"[[Claude Code]]"| T1
+        B2 -.->|"[[AI Coding IDEs]]"| T3
+    end
+```
+
+#### Wikilink Strategy
+
+The Obsidian markdown uses `[[wikilinks]]` extensively to create graph connections:
+
+| Element | Wikilink Placement | Graph Effect |
+|---------|-------------------|--------------|
+| Section headings | `## [[Claude Code]] / [[Anthropic]]` | Briefing → topic edges |
+| Related topics line | `Related topics: [[AI Coding]], [[LLMs]], ...` | Cross-topic edges |
+| Inline mentions | `...announced by [[OpenAI]] today...` | Entity edges |
+| Topic stub pages | `Topics/Claude Code.md` with backlinks | Hub nodes in graph |
+
+#### Topic Stub Pages
+
+The publish script extracts all `[[wikilinks]]` from the briefing markdown and creates stub pages in `Topics/` for any that don't already exist. Each stub has YAML frontmatter:
+
+```yaml
+---
+type: topic
+created: 2026-04-11
+---
+
+# Claude Code
+
+> Auto-generated topic page. Briefings mentioning this topic will appear as backlinks.
+```
+
+This creates a growing knowledge graph where topics accumulate backlinks from each briefing that mentions them.
+
+#### Files Involved
+
+| File | Purpose |
+|------|---------|
+| `scripts/publish-obsidian.sh` | Bash: copies markdown to vault, creates topic stubs |
+| `scripts/publish-obsidian.ps1` | PowerShell: equivalent Windows implementation |
+| `scripts/test-obsidian.sh` | Bash: vault connectivity test (directory, permissions, config) |
+| `scripts/test-obsidian.ps1` | PowerShell: equivalent Windows implementation |
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AI_BRIEFING_OBSIDIAN_VAULT` | Yes | Absolute path to the Obsidian vault root directory |
+
+#### Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Vault env var not set | Skip publishing silently (opt-in feature) |
+| Vault directory missing | Error message, skip publishing, log warning |
+| Vault not writable | Error message, skip publishing, log warning |
+| Obsidian markdown not generated | Warning message, skip publishing |
+| Topic stub already exists | Skip creation, count as existing |
+| Publish script missing | Warning message, skip publishing |
+
+### 3.13 Test Suite
+
+201 non-blocking tests across bash and PowerShell verify the entire system without calling external services. Tests cover syntax, structure, argument handling, template substitution, card JSON validation, notification error paths, Obsidian publishing, and cross-platform portability.
 
 #### Test Architecture
 
 ```mermaid
 flowchart TD
     subgraph "Bash (macOS / Linux / Git Bash)"
-        R["tests/run-all.sh"] --> T1["test-custom-brief.sh<br/>37 tests"]
-        R --> T2["test-daily-brief.sh<br/>56 tests"]
-        R --> T3["test-notifications.sh<br/>37 tests"]
+        R["tests/run-all.sh"] --> T1["test-custom-brief.sh<br/>48 tests"]
+        R --> T2["test-daily-brief.sh<br/>80 tests"]
+        R --> T3["test-notifications.sh<br/>17 tests"]
         R --> T4["test-portability.sh<br/>26 tests"]
+        R --> T5["test-obsidian.sh<br/>30 tests"]
     end
 
     subgraph "PowerShell (Windows)"
@@ -670,6 +773,8 @@ flowchart TD
         T2 --> X2["Prompt steps, 9 topics, 8 changelogs,<br/>entry scripts, dedup file"]
         T3 --> X3["Card JSON validity, Adaptive Card structure,<br/>Teams-to-Slack converter, error handling"]
         T4 --> X4["Bash 3.2 compat, awk/date portability,<br/>-f vs -x checks, ANSI color safety"]
+
+        T5 --> X5["Publish script structure, wikilink extraction,<br/>error handling, vault simulation"]
         PS --> X1
         PS --> X2
         PS --> X3
@@ -692,9 +797,10 @@ flowchart TD
 | File | Tests | Focus |
 |---|---|---|
 | `tests/run-all.sh` | -- | Runner: executes all `test-*.sh` suites |
-| `tests/test-custom-brief.sh` | 37 | Custom brief: args, template, prompt, skill |
-| `tests/test-daily-brief.sh` | 56 | Daily brief: prompt, topics, changelogs, scripts |
-| `tests/test-notifications.sh` | 37 | Notifications: card JSON, converter, error paths |
+| `tests/test-custom-brief.sh` | 48 | Custom brief: args, template, prompt, skill, Obsidian |
+| `tests/test-daily-brief.sh` | 80 | Daily brief: prompt, topics, changelogs, scripts, Obsidian |
+| `tests/test-notifications.sh` | 17 | Notifications: card JSON, converter, error paths |
+| `tests/test-obsidian.sh` | 30 | Obsidian: publish script, wikilinks, vault simulation |
 | `tests/test-portability.sh` | 26 | Cross-platform: bash version, awk, date, colors |
 | `tests/test-all.ps1` | 91 | PowerShell: syntax, prompts, cards, converter, docs |
 
@@ -985,6 +1091,8 @@ graph TD
     SC --> SC4["topic-edit.sh/.ps1"]
     SC --> SC5["notify-teams.sh/.ps1"]
     SC --> SC8["notify-slack.sh/.ps1"]
+    SC --> SC10["publish-obsidian.sh/.ps1"]
+    SC --> SC11["test-obsidian.sh/.ps1"]
     SC --> SC9["teams-to-slack.py"]
     SC --> SC6["build-teams-card.py (legacy)"]
     SC --> SC7["+ 8 more pairs"]
@@ -1001,6 +1109,7 @@ graph TD
 
     G --> G1["YYYY-MM-DD.log"]
     G --> G4["YYYY-MM-DD-card.json"]
+    G --> G5["YYYY-MM-DD-obsidian.md"]
     G --> G2["launchd-stdout.log (macOS)"]
     G --> G3["launchd-stderr.log (macOS)"]
 
@@ -1034,12 +1143,17 @@ graph TD
 | `scripts/notify-teams.ps1` | Windows | Teams notification entry point (PowerShell) | Yes |
 | `scripts/notify-slack.sh` | macOS/Linux | Slack notification entry point (Bash) | Yes |
 | `scripts/notify-slack.ps1` | Windows | Slack notification entry point (PowerShell) | Yes |
+| `scripts/publish-obsidian.sh` | macOS/Linux | Obsidian vault publisher (Bash) — copies markdown, creates topic stubs | Yes |
+| `scripts/publish-obsidian.ps1` | Windows | Obsidian vault publisher (PowerShell) | Yes |
+| `scripts/test-obsidian.sh` | macOS/Linux | Obsidian vault connectivity test (Bash) | Yes |
+| `scripts/test-obsidian.ps1` | Windows | Obsidian vault connectivity test (PowerShell) | Yes |
 | `scripts/teams-to-slack.py` | Shared | Converts Teams Adaptive Card JSON to Slack Block Kit JSON | Yes |
 | `scripts/build-teams-card.py` | Shared | **Legacy.** Old log-parsing card builder. No longer referenced. | Yes |
 | `scripts/*.sh` | macOS/Linux | Utility scripts (12 tools) | Yes |
 | `scripts/*.ps1` | Windows | Utility scripts (12 tools) | Yes |
 | `logs/*.log` | Shared | Daily run logs | No (gitignored) |
 | `logs/*-card.json` | Shared | Adaptive Card JSON written by Claude Code (Step 4). POSTed to Teams as-is. | No (gitignored) |
+| `logs/*-obsidian.md` | Shared | Obsidian-formatted markdown with `[[wikilinks]]` written by Claude Code (Step 5). Published to vault by `publish-obsidian.sh/.ps1`. | No (gitignored) |
 | `backups/` | Shared | Timestamped prompt.md backups | No (gitignored) |
 | `~/.local/bin/ai-news` | macOS | Manual trigger CLI script | No (outside repo) |
 
@@ -1048,7 +1162,8 @@ graph TD
 1. **Created**: At the start of each run, the entry script creates (or appends to) `logs/YYYY-MM-DD.log`.
 2. **Appended**: Claude Code's full stdout and stderr are appended. Multiple runs on the same day share one log file.
 3. **Card JSON**: Claude Code writes `logs/YYYY-MM-DD-card.json` as Step 4 of the briefing skill. This file is the exact Adaptive Card payload sent to Teams and is also the source for the Slack Block Kit conversion.
-4. **Rotated**: At the end of each run, logs older than 30 days are deleted.
+4. **Obsidian markdown**: Claude Code writes `logs/YYYY-MM-DD-obsidian.md` as Step 5 of the briefing skill. This file contains the full briefing formatted with YAML frontmatter and `[[wikilinks]]` for Obsidian's graph view. The publish script copies it to the vault.
+5. **Rotated**: At the end of each run, logs older than 30 days are deleted.
 5. **launchd logs** (macOS only): `launchd-stdout.log` and `launchd-stderr.log` capture output from launchd itself. These are not rotated automatically.
 
 ---
@@ -1085,13 +1200,13 @@ The Notion MCP tool authenticates via credentials managed by Claude Code's MCP c
 
 ### Environment Variables
 
-No secrets are stored in any tracked file. Claude Code's API key and Notion integration token are managed externally by the Claude Code and MCP runtime. The macOS plist explicitly sets `PATH` and `HOME` for deterministic execution; the Windows task inherits the user's environment.
+No secrets are stored in any tracked file. Claude Code's API key and Notion integration token are managed externally by the Claude Code and MCP runtime. The `AI_BRIEFING_OBSIDIAN_VAULT` variable contains only a local file path and poses no credential risk. The macOS plist explicitly sets `PATH` and `HOME` for deterministic execution; the Windows task inherits the user's environment.
 
 ---
 
-## 11. Teams and Slack Notification Pipelines
+## 11. Teams, Slack, and Obsidian Pipelines
 
-See [Section 3.9](#39-teams-notification-pipeline) and [Section 3.10](#310-slack-notification-pipeline) for full architectural details. See also [NOTIFY_TEAMS.md](NOTIFY_TEAMS.md), [NOTIFY_SLACK.md](NOTIFY_SLACK.md), and `E2E_FLOW.md` for end-to-end walkthroughs and failure modes.
+See [Section 3.9](#39-teams-notification-pipeline), [Section 3.10](#310-slack-notification-pipeline), and [Section 3.12](#312-obsidian-publishing-pipeline) for full architectural details. See also [NOTIFY_TEAMS.md](NOTIFY_TEAMS.md), [NOTIFY_SLACK.md](NOTIFY_SLACK.md), and `E2E_FLOW.md` for end-to-end walkthroughs and failure modes.
 
 ---
 
@@ -1119,6 +1234,7 @@ Set the `AI_BRIEFING_MODEL` environment variable, or change `--model sonnet` in 
 |---|---|---|
 | Microsoft Teams | **Implemented** | Claude Code writes Adaptive Card JSON (Step 4), `notify-teams.sh/.ps1` validates and POSTs to Power Automate webhook. See [Section 3.9](#39-teams-notification-pipeline). |
 | Slack | **Implemented** | `notify-slack.sh/.ps1` converts the Teams card JSON to Slack Block Kit using `teams-to-slack.py` and POSTs to Slack webhook. See [Section 3.10](#310-slack-notification-pipeline). |
+| Obsidian | **Implemented** | Claude Code writes graph-ready markdown (Step 5) with `[[wikilinks]]` and YAML frontmatter. `publish-obsidian.sh/.ps1` copies to vault and creates topic stub pages. See [Section 3.12](#312-obsidian-publishing-pipeline). |
 | macOS notification | Planned | `osascript -e 'display notification ...'` in `briefing.sh` |
 | Windows toast | Planned | `New-BurntToastNotification` or `[Windows.UI.Notifications]` in `briefing.ps1` |
 | Email | Planned | `mail`/`sendmail` (macOS) or `Send-MailMessage` (Windows) in the entry script |
@@ -1146,7 +1262,7 @@ The log files follow a predictable naming convention (`YYYY-MM-DD.log`) and cont
 | Run manually | `make run` | `ai-news` | `schtasks /run /tn AiNewsBriefing` |
 | Run in background | `make run-bg` | `nohup bash briefing.sh &` | `Start-Process powershell briefing.ps1` |
 | Custom brief | `make custom-brief T="topic"` | `bash custom-brief.sh --topic "topic"` | `.\custom-brief.ps1 -Topic "topic"` |
-| Custom brief + publish | `make custom-brief T="topic" NOTION=1 TEAMS=1` | `bash custom-brief.sh -t "topic" -n --teams` | `.\custom-brief.ps1 -Topic "topic" -Notion -Teams` |
+| Custom brief + publish | `make custom-brief T="topic" NOTION=1 TEAMS=1 OBSIDIAN=1` | `bash custom-brief.sh -t "topic" -n --teams -o` | `.\custom-brief.ps1 -Topic "topic" -Notion -Teams -Obsidian` |
 | Tail live log | `make tail` | `tail -f logs/YYYY-MM-DD.log` | `Get-Content "logs\YYYY-MM-DD.log" -Wait` |
 | Check job status | `make status` | `launchctl list \| grep ainews` | `schtasks /query /tn AiNewsBriefing` |
 | Install scheduler | `make install` | `launchctl load ~/Library/LaunchAgents/...` | `.\install-task.ps1` |

--- a/CUSTOM_BRIEF.md
+++ b/CUSTOM_BRIEF.md
@@ -1,6 +1,6 @@
 # Custom Brief: Deep Topic Research
 
-Deep-research any topic and produce a comprehensive news-focused briefing with linked citations and publication dates. Publishes to Notion, Microsoft Teams, and/or Slack -- or just prints to the terminal.
+Deep-research any topic and produce a comprehensive news-focused briefing with linked citations and publication dates. Publishes to Notion, Obsidian, Microsoft Teams, and/or Slack -- or just prints to the terminal.
 
 This feature complements the daily AI news briefing by letting you go deep on a specific subject whenever you need it, rather than covering 9 broad categories on a daily schedule.
 
@@ -39,6 +39,8 @@ flowchart TD
     subgraph "Output"
         S -->|Always| STDOUT[Terminal Output]
         S -->|If --notion| N[Notion Page]
+        S -->|If --obsidian| OB[Obsidian Vault]
+        OB -->|publish-obsidian.sh| OBV["AI-News-Briefings/ + Topics/"]
         S -->|If --teams or --slack| CARD[Card JSON]
         CARD -->|notify-teams.sh/.ps1| TW[Teams Webhook]
         CARD -->|notify-slack.sh/.ps1| SW[Slack Webhook]
@@ -64,37 +66,40 @@ flowchart TD
 
 ```bash
 # All destinations
-./custom-brief.sh --topic "AI in healthcare" --notion --teams --slack
+./custom-brief.sh --topic "AI in healthcare" --notion --obsidian --teams --slack
 
-# Notion only
-./custom-brief.sh --topic "quantum computing breakthroughs" --notion
+# Notion + Obsidian
+./custom-brief.sh --topic "quantum computing breakthroughs" --notion --obsidian
+
+# Obsidian only (graph visualization)
+./custom-brief.sh --topic "open source LLMs 2026" --obsidian
 
 # Terminal only (no publishing)
 ./custom-brief.sh --topic "open source LLMs 2026"
 
 # Short flags
-./custom-brief.sh -t "AI regulation EU" -n
+./custom-brief.sh -t "AI regulation EU" -n -o
 
 # Use a specific engine
-./custom-brief.sh --cli codex --topic "AI safety" --notion
+./custom-brief.sh --cli codex --topic "AI safety" --notion --obsidian
 ./custom-brief.sh --cli gemini -t "quantum computing" -n
 ```
 
 **PowerShell:**
 
 ```powershell
-.\custom-brief.ps1 -Topic "AI in healthcare" -Notion -Teams -Slack
-.\custom-brief.ps1 -Topic "quantum computing" -Notion
-.\custom-brief.ps1 -Cli gemini -Topic "AI safety" -Notion
+.\custom-brief.ps1 -Topic "AI in healthcare" -Notion -Obsidian -Teams -Slack
+.\custom-brief.ps1 -Topic "quantum computing" -Notion -Obsidian
+.\custom-brief.ps1 -Cli gemini -Topic "AI safety" -Notion -Obsidian
 ```
 
 **Make:**
 
 ```bash
-make custom-brief T="AI in healthcare" NOTION=1 TEAMS=1
-make custom-brief T="quantum computing" NOTION=1
-make custom-brief T="AI safety" CLI=codex NOTION=1
-make custom-brief-bg T="open source LLMs" NOTION=1  # background
+make custom-brief T="AI in healthcare" NOTION=1 OBSIDIAN=1 TEAMS=1
+make custom-brief T="quantum computing" NOTION=1 OBSIDIAN=1
+make custom-brief T="AI safety" CLI=codex NOTION=1 OBSIDIAN=1
+make custom-brief-bg T="open source LLMs" NOTION=1 OBSIDIAN=1  # background
 ```
 
 ### Interactive REPL
@@ -116,9 +121,10 @@ Run without arguments to enter interactive mode. The REPL shows which AI engines
 
   Topic: AI in drug discovery
 
-  Publish to Notion? [y/N]: y
-  Publish to Teams?  [y/N]: y
-  Publish to Slack?  [y/N]: n
+  Publish to Notion?   [y/N]: y
+  Publish to Obsidian? [y/N]: y
+  Publish to Teams?    [y/N]: y
+  Publish to Slack?    [y/N]: n
 ```
 
 ### Claude Code Skill
@@ -142,6 +148,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | `--topic`, `-t` | Topic to research (required in non-interactive mode) |
 | `--cli` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `--notion`, `-n` | Publish briefing to Notion |
+| `--obsidian`, `-o` | Publish briefing to Obsidian vault (requires `AI_BRIEFING_OBSIDIAN_VAULT`) |
 | `--teams` | Send Adaptive Card to Teams |
 | `--slack` | Send Block Kit message to Slack |
 | `--help`, `-h` | Show usage help |
@@ -153,6 +160,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | `-Topic` | Topic to research (required in non-interactive mode) |
 | `-Cli` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `-Notion` | Publish briefing to Notion |
+| `-Obsidian` | Publish briefing to Obsidian vault (requires `AI_BRIEFING_OBSIDIAN_VAULT`) |
 | `-Teams` | Send Adaptive Card to Teams |
 | `-Slack` | Send Block Kit message to Slack |
 
@@ -163,6 +171,7 @@ Claude will ask for the topic and destinations, then run the research pipeline i
 | `T` | Topic (required) |
 | `CLI` | AI engine to use: `claude`, `codex`, `gemini`, `copilot` (default: auto-detect) |
 | `NOTION` | Set to `1` to publish to Notion |
+| `OBSIDIAN` | Set to `1` to publish to Obsidian vault |
 | `TEAMS` | Set to `1` to send to Teams |
 | `SLACK` | Set to `1` to send to Slack |
 
@@ -189,6 +198,16 @@ Created in the same database as daily briefings with the title format:
 YYYY-MM-DD - Custom Brief: [Topic]
 ```
 
+### Obsidian Page (optional)
+
+Written to your Obsidian vault at `AI-News-Briefings/YYYY-MM-DD - Custom Brief - [Topic].md`. Includes:
+
+- **YAML frontmatter** with date, type, topic, tags
+- **`[[wikilinks]]`** to topic pages for graph visualization
+- **Related topics line** linking to all referenced topics
+
+Topic stub pages are auto-created in `Topics/` on first reference. Open Obsidian's graph view (`Ctrl/Cmd + G`) to see how briefings connect through shared topics.
+
 ### Teams Adaptive Card (optional)
 
 Written to `logs/custom-YYYY-MM-DD-HHMMSS-card.json`, then POSTed by `notify-teams.sh/.ps1`. Same card structure as the daily briefing, with the header showing the custom topic.
@@ -207,9 +226,15 @@ ai-news-briefing/
   custom-brief.ps1             # PowerShell CLI entry point
   prompt-custom-brief.md       # Research prompt template
   commands/custom-brief.md     # Claude Code interactive skill
+  scripts/
+    publish-obsidian.sh        # Copies markdown to Obsidian vault + creates topic stubs
+    publish-obsidian.ps1       # Windows equivalent
+    test-obsidian.sh           # Tests Obsidian vault connectivity
+    test-obsidian.ps1          # Windows equivalent
   logs/
-    custom-YYYY-MM-DD-HHMMSS.log       # Execution log
-    custom-YYYY-MM-DD-HHMMSS-card.json # Adaptive Card (if generated)
+    custom-YYYY-MM-DD-HHMMSS.log            # Execution log
+    custom-YYYY-MM-DD-HHMMSS-card.json      # Adaptive Card (if generated)
+    custom-YYYY-MM-DD-HHMMSS-obsidian.md    # Obsidian markdown (if generated)
 ```
 
 ---

--- a/E2E_FLOW.md
+++ b/E2E_FLOW.md
@@ -10,6 +10,8 @@ It is based on the current implementation in:
 - `scripts/notify-teams.ps1`
 - `scripts/notify-slack.sh`
 - `scripts/notify-slack.ps1`
+- `scripts/publish-obsidian.sh`
+- `scripts/publish-obsidian.ps1`
 - `scripts/teams-to-slack.py`
 - `scripts/build-teams-card.py` (legacy reference)
 - `Makefile`
@@ -46,6 +48,7 @@ flowchart TD
 
     D --> H[logs/YYYY-MM-DD.log\nstdout + stderr appended]
     D --> I[Expected Teams artifact\nlogs/YYYY-MM-DD-card.json]
+    D --> I2[Expected Obsidian artifact\nlogs/YYYY-MM-DD-obsidian.md]
 
     B1 --> J{AI_BRIEFING_TEAMS_WEBHOOK set?}
     B2 --> J
@@ -64,6 +67,15 @@ flowchart TD
     U -->|No| V[Slack notify fails\nrun still completed]
     U -->|Yes| W[Convert + POST to Slack webhooks]
     W --> X[Slack channel message]
+
+    B1 --> OC{AI_BRIEFING_OBSIDIAN_VAULT set?}
+    B2 --> OC
+    OC -->|No| OD[Skip Obsidian publish]
+    OC -->|Yes| OE[publish-obsidian.sh / publish-obsidian.ps1]
+    OE --> OF{obsidian.md exists?}
+    OF -->|No| OG[Obsidian publish skipped\nrun still completed]
+    OF -->|Yes| OH[Copy to vault + create topic stubs]
+    OH --> OI[Obsidian vault updated\nGraph view shows connections]
 
     B1 --> Q[Delete *.log older than 30 days]
     B2 --> Q
@@ -86,6 +98,8 @@ sequenceDiagram
     participant TW as Teams Webhook(s)
     participant S2 as notify-slack
     participant SW as Slack Webhook(s)
+    participant OB as publish-obsidian
+    participant OV as Obsidian Vault
 
     S->>E: Start briefing.sh or briefing.ps1
     E->>E: Resolve dirs and date
@@ -116,6 +130,12 @@ sequenceDiagram
     SW-->>S2: 2xx
     S2-->>E: success
 
+    E->>OB: Call publish-obsidian (if vault env var set)
+    OB->>OB: Read obsidian.md, extract [[wikilinks]]
+    OB->>OV: Copy briefing + create topic stubs
+    OV-->>OB: success
+    OB-->>E: success
+
     E->>E: Cleanup logs older than 30 days
 ```
 
@@ -142,7 +162,8 @@ Entry scripts do the same core setup:
 6. Append output to `logs/YYYY-MM-DD.log`.
 7. Attempt Teams notify when Teams webhook env var is present.
 8. Attempt Slack notify when Slack webhook env var is present.
-9. Delete only old `*.log` files (>30 days).
+9. Attempt Obsidian publish when vault env var is present.
+10. Delete only old `*.log` files (>30 days).
 
 ### Stage B: Date Override / Backfill Path
 
@@ -168,9 +189,10 @@ When date override is used, scripts prepend a runtime instruction block to the p
 4. Step 2: compile TL;DR + full briefing sections with dates.
 5. Step 3: if `PAGE_EXISTS = true`, update the existing Notion page. Otherwise, create a new page. This prevents duplicate pages on re-runs.
 6. Step 4: write Adaptive Card JSON to `logs/YYYY-MM-DD-card.json`.
-7. Step 5: append today's headlines to `logs/covered-stories.txt`.
+7. Step 5: write Obsidian-formatted markdown with `[[wikilinks]]` to `logs/YYYY-MM-DD-obsidian.md`.
+8. Step 6: append today's headlines to `logs/covered-stories.txt`.
 
-### Stage D: Teams & Slack Delivery
+### Stage D: Teams, Slack & Obsidian Delivery
 
 **Teams** notifier scripts are intentionally thin:
 
@@ -188,14 +210,23 @@ When date override is used, scripts prepend a runtime instruction block to the p
 
 Neither builds cards from logs. Both are resilient to individual webhook failures.
 
+**Obsidian** publisher scripts are local-only (no network calls):
+
+- Find Obsidian markdown file (default `logs/<today>-obsidian.md`, or passed as argument).
+- Validate vault directory exists and is writable.
+- Copy markdown to `AI-News-Briefings/` subdirectory in the vault, stripping the `-obsidian` suffix.
+- Extract all `[[wikilinks]]` from the markdown and create topic stub pages in `Topics/` for any new topics.
+- Topic stubs include YAML frontmatter (`type: topic`, `created: date`) and serve as graph hub nodes.
+
 ---
 
-## 4. Notification Decision Graph (Teams + Slack)
+## 4. Notification & Publishing Decision Graph (Teams + Slack + Obsidian)
 
 ```mermaid
 flowchart TD
     A[Entry script success] --> B{Teams webhook env set?}
     A --> C{Slack webhook env set?}
+    A --> OA{Obsidian vault env set?}
 
     B -->|No| D[Skip Teams step]
     B -->|Yes| E[Call notify-teams]
@@ -214,6 +245,13 @@ flowchart TD
     P --> Q{Any HTTP 2xx?}
     Q -->|No| R[Slack notify failed]
     Q -->|Yes| S[Slack notify success]
+
+    OA -->|No| OB[Skip Obsidian step]
+    OA -->|Yes| OC[Call publish-obsidian]
+    OC --> OD{obsidian.md exists\nand vault writable?}
+    OD -->|No| OE[Obsidian publish failed]
+    OD -->|Yes| OF[Copy to vault\n+ create topic stubs]
+    OF --> OG[Obsidian publish success]
 ```
 
 ---
@@ -227,6 +265,7 @@ The prompt and runtime pipeline are aligned on a shared card artifact and dual-c
 | `prompt.md` Step 4 | AI writes `logs/YYYY-MM-DD-card.json` directly |
 | `scripts/notify-teams.sh/.ps1` | Validates and POSTs the prebuilt card JSON |
 | `scripts/notify-slack.sh/.ps1` | Converts prebuilt card JSON to Block Kit and POSTs it |
+| `scripts/publish-obsidian.sh/.ps1` | Copies Obsidian markdown to vault, creates topic stub pages |
 | `scripts/teams-to-slack.py` | Conversion layer from Teams Adaptive Card schema to Slack Block Kit |
 | `scripts/build-teams-card.py` | Legacy parser, not called by any active script |
 
@@ -266,13 +305,26 @@ stateDiagram-v2
     SlackFailed --> Cleanup
     SlackDone --> Cleanup
 
+    SlackSkipped --> ObsidianCheck
+    SlackFailed --> ObsidianCheck
+    SlackDone --> ObsidianCheck
+
+    ObsidianCheck --> ObsidianSkipped: vault env not set
+    ObsidianCheck --> ObsidianPublishAttempt: vault env set
+    ObsidianPublishAttempt --> ObsidianFailed: missing md / vault error
+    ObsidianPublishAttempt --> ObsidianDone: obsidian publish success
+
+    ObsidianSkipped --> Cleanup
+    ObsidianFailed --> Cleanup
+    ObsidianDone --> Cleanup
+
     Cleanup --> [*]
 ```
 
 Notes:
 
-- Teams and Slack notification failures do not currently mark the whole run as failed at the script level.
-- Log cleanup only targets `*.log`; old `*-card.json` files are not rotated by current scripts.
+- Teams, Slack, and Obsidian failures do not currently mark the whole run as failed at the script level.
+- Log cleanup only targets `*.log`; old `*-card.json` and `*-obsidian.md` files are not rotated by current scripts.
 
 ---
 
@@ -283,6 +335,7 @@ Notes:
 | `logs/YYYY-MM-DD.log` | entry scripts + Claude stdout/stderr | humans, diagnostic scripts | No (diagnostic) |
 | Notion page | Claude via Notion MCP | Notion workspace | Yes |
 | `logs/YYYY-MM-DD-card.json` | Claude (expected) | notify-teams scripts, notify-slack scripts, teams-to-slack.py | Yes for Teams and Slack paths |
+| `logs/YYYY-MM-DD-obsidian.md` | Claude (expected) | publish-obsidian scripts | Yes for Obsidian path |
 | Converted Slack payload (temp) | notify-slack scripts | Slack webhook endpoint | Yes for Slack path |
 | Teams message | notify-teams scripts | Teams channel | Optional |
 | Slack message | notify-slack scripts | Slack channel | Optional |
@@ -294,9 +347,11 @@ Notes:
 1. Ensure Claude CLI path exists (`~/.local/bin/claude` or `.exe`).
 2. Ensure Notion MCP is configured and has DB access.
 3. Ensure `prompt.md` Step 4 still writes `logs/YYYY-MM-DD-card.json`.
-4. If Teams is enabled, verify `AI_BRIEFING_TEAMS_WEBHOOK` and direct `notify-teams` test.
-5. If Slack is enabled, verify `AI_BRIEFING_SLACK_WEBHOOK`, Python availability, and direct `notify-slack` test.
-6. Use `make tail` / `make log` to inspect run outcomes.
+4. Ensure `prompt.md` Step 5 still writes `logs/YYYY-MM-DD-obsidian.md`.
+5. If Teams is enabled, verify `AI_BRIEFING_TEAMS_WEBHOOK` and direct `notify-teams` test.
+6. If Slack is enabled, verify `AI_BRIEFING_SLACK_WEBHOOK`, Python availability, and direct `notify-slack` test.
+7. If Obsidian is enabled, verify `AI_BRIEFING_OBSIDIAN_VAULT` points to a valid vault and run `bash scripts/test-obsidian.sh`.
+8. Use `make tail` / `make log` to inspect run outcomes.
 
 ---
 
@@ -305,4 +360,5 @@ Notes:
 - **Duplicate Notion page prevention:** Step 0b now captures `PAGE_EXISTS` and the page ID. Step 3 updates the existing page when one is found, and only creates a new page otherwise. The agent no longer re-queries Notion in Step 3.
 - **Multiple webhook support:** Both `AI_BRIEFING_TEAMS_WEBHOOK` and `AI_BRIEFING_SLACK_WEBHOOK` accept semicolon-separated URLs. By default only the first URL is used. Pass `--all` (bash) or `-All` (PowerShell) to post to all configured URLs.
 - **Slack integration:** `notify-slack.sh/.ps1` converts the Teams card JSON to Slack Block Kit format using `teams-to-slack.py` and POSTs it to Slack webhooks. No separate card generation needed — reuses the Teams card.
-- **Prompt/runtime alignment:** `prompt.md` Step 4 now writes `logs/YYYY-MM-DD-card.json` directly. The legacy `build-teams-card.py` parser is no longer part of the active pipeline.
+- **Obsidian integration:** `publish-obsidian.sh/.ps1` copies graph-ready markdown (with `[[wikilinks]]` and YAML frontmatter) to an Obsidian vault. Topic stub pages are auto-created for graph connectivity. Set `AI_BRIEFING_OBSIDIAN_VAULT` to enable.
+- **Prompt/runtime alignment:** `prompt.md` Step 4 now writes `logs/YYYY-MM-DD-card.json` directly. Step 5 writes `logs/YYYY-MM-DD-obsidian.md`. The legacy `build-teams-card.py` parser is no longer part of the active pipeline.

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,13 @@ else
 	@echo "Running (PID $$!). Tail log with: make tail"
 endif
 
-custom-brief: check ## Deep-research a topic. Usage: make custom-brief T="topic" CLI=codex NOTION=1 TEAMS=1 SLACK=1
+custom-brief: check ## Deep-research a topic. Usage: make custom-brief T="topic" CLI=codex NOTION=1 OBSIDIAN=1 TEAMS=1 SLACK=1
 ifeq ($(PLATFORM),windows)
 	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/custom-brief.ps1" \
 		$(if $(T),-Topic "$(T)") \
 		$(if $(CLI),-Cli $(CLI)) \
 		$(if $(NOTION),-Notion) \
+		$(if $(OBSIDIAN),-Obsidian) \
 		$(if $(TEAMS),-Teams) \
 		$(if $(SLACK),-Slack)
 else
@@ -74,17 +75,19 @@ else
 		$(if $(T),--topic "$(T)") \
 		$(if $(CLI),--cli $(CLI)) \
 		$(if $(NOTION),--notion) \
+		$(if $(OBSIDIAN),--obsidian) \
 		$(if $(TEAMS),--teams) \
 		$(if $(SLACK),--slack)
 endif
 
-custom-brief-bg: check ## Deep-research in background. Usage: make custom-brief-bg T="topic" CLI=gemini NOTION=1
+custom-brief-bg: check ## Deep-research in background. Usage: make custom-brief-bg T="topic" CLI=gemini NOTION=1 OBSIDIAN=1
 ifeq ($(PLATFORM),windows)
 	@echo "Starting custom brief in background..."
 	@powershell -ExecutionPolicy Bypass -File "$(SCRIPT_DIR)/custom-brief.ps1" \
 		$(if $(T),-Topic "$(T)") \
 		$(if $(CLI),-Cli $(CLI)) \
 		$(if $(NOTION),-Notion) \
+		$(if $(OBSIDIAN),-Obsidian) \
 		$(if $(TEAMS),-Teams) \
 		$(if $(SLACK),-Slack) &
 	@echo "Running. Check logs/custom-*.log"
@@ -94,6 +97,7 @@ else
 		$(if $(T),--topic "$(T)") \
 		$(if $(CLI),--cli $(CLI)) \
 		$(if $(NOTION),--notion) \
+		$(if $(OBSIDIAN),--obsidian) \
 		$(if $(TEAMS),--teams) \
 		$(if $(SLACK),--slack) >/dev/null 2>&1 &
 	@echo "Running (PID $$!). Check logs/custom-*.log"
@@ -214,7 +218,9 @@ validate: check ## Validate all project files exist and are well-formed
 	@echo "Checking project files..."
 	@errors=0; \
 	for f in prompt.md briefing.sh briefing.ps1 com.ainews.briefing.plist install-task.ps1 \
-	         prompt-custom-brief.md custom-brief.sh custom-brief.ps1 commands/custom-brief.md; do \
+	         prompt-custom-brief.md custom-brief.sh custom-brief.ps1 commands/custom-brief.md \
+	         scripts/publish-obsidian.sh scripts/publish-obsidian.ps1 \
+	         scripts/test-obsidian.sh scripts/test-obsidian.ps1; do \
 		if [ -f "$(SCRIPT_DIR)/$$f" ]; then \
 			printf "  %-36s \033[32mOK\033[0m\n" "$$f"; \
 		else \
@@ -229,7 +235,7 @@ validate: check ## Validate all project files exist and are well-formed
 	fi
 	@echo ""
 	@echo "Checking prompt.md structure..."
-	@for section in "Step 0" "Step 1" "Step 2" "Step 3"; do \
+	@for section in "Step 0" "Step 1" "Step 2" "Step 3" "Step 4" "Step 5" "Step 6"; do \
 		if grep -q "$$section" "$(SCRIPT_DIR)/prompt.md"; then \
 			printf "  %-36s \033[32mOK\033[0m\n" "$$section"; \
 		else \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![GitHub Copilot CLI](https://img.shields.io/badge/GitHub_Copilot-CLI-238636?logo=githubcopilot&logoColor=white)
 ![WebSearch Tool](https://img.shields.io/badge/WebSearch_Tool-Integrated-10b981?logo=claude&logoColor=white)
 ![Notion](https://img.shields.io/badge/Notion-MCP-000000?logo=notion&logoColor=white)
+![Obsidian](https://img.shields.io/badge/Obsidian-Graph_View-7C3AED?logo=obsidian&logoColor=white)
 ![MCP](https://img.shields.io/badge/Model_Context_Protocol-1.0-10b981?logo=modelcontextprotocol&logoColor=white)
 ![Adaptive Cards](https://img.shields.io/badge/Adaptive_Cards-v1.4-0078D4?logo=json&logoColor=white)
 ![Bash](https://img.shields.io/badge/Bash-Script-4EAA25?logo=gnubash&logoColor=white)
@@ -20,13 +21,13 @@
 ![Slack](https://img.shields.io/badge/Slack-Webhook-4A154B?logo=slack&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)
-![Tests](https://img.shields.io/badge/Shell_Tests-247_Passing-10b981?logo=checkmarx&logoColor=white)
+![Tests](https://img.shields.io/badge/Shell_Tests-201_Passing-10b981?logo=checkmarx&logoColor=white)
 ![ANSI Colors](https://img.shields.io/badge/CLI-Styled_Output-ff6b6b?logo=windowsterminal&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-Version_Control-F05032?logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github&logoColor=white)
 ![License](https://img.shields.io/badge/License-MIT-000000?logo=mit&logoColor=white)
 
-Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion, and delivers a styled summary to Microsoft Teams and Slack -- powered by Claude Code, Codex, Gemini, or Copilot CLIs with automatic fallback. Supports both macOS (launchd) and Windows (Task Scheduler). Includes an on-demand **Custom Brief** mode for deep multi-agent research on any topic. Fully automated pipeline with zero manual intervention required after setup.
+Automated daily AI news research agent that searches the web, compiles a structured briefing, publishes it to Notion and/or Obsidian, and delivers a styled summary to Microsoft Teams and Slack -- powered by Claude Code, Codex, Gemini, or Copilot CLIs with automatic fallback. Supports both macOS (launchd) and Windows (Task Scheduler). Includes an on-demand **Custom Brief** mode for deep multi-agent research on any topic. Obsidian integration enables **graph visualization** of topic relationships across briefings. Fully automated pipeline with zero manual intervention required after setup.
 
 > [!NOTE]
 > **Live AI News Notion page:** [https://hoangsonw.notion.site/9c34d052d9354beda82a3423e2d2f404?v=d43c53fe405c4896bfd95ad0cc22246f](https://hoangsonw.notion.site/9c34d052d9354beda82a3423e2d2f404?v=d43c53fe405c4896bfd95ad0cc22246f)
@@ -35,11 +36,11 @@ Automated daily AI news research agent that searches the web, compiles a structu
 
 ## Overview
 
-AI News Briefing is a fully automated pipeline that runs every morning on your machine. It supports four AI CLI engines -- Claude Code, Codex (OpenAI), Gemini (Google), and Copilot (GitHub) -- with automatic fallback if your preferred engine is unavailable. The selected engine runs in headless mode as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), writing the finished page directly to a Notion database, and optionally posting a styled Adaptive Card summary to Microsoft Teams and Slack.
+AI News Briefing is a fully automated pipeline that runs every morning on your machine. It supports four AI CLI engines -- Claude Code, Codex (OpenAI), Gemini (Google), and Copilot (GitHub) -- with automatic fallback if your preferred engine is unavailable. The selected engine runs in headless mode as a news research agent: searching the web across 9 AI-related topics, compiling the results into a two-tier briefing (TL;DR + full report), writing the finished page directly to a Notion database, optionally publishing to an Obsidian vault with graph-ready wikilinks, and optionally posting a styled Adaptive Card summary to Microsoft Teams and Slack.
 
-The entire process -- from triggering to publishing -- requires zero human intervention. You wake up, open Notion (or Teams or Slack), and your daily AI briefing is already there.
+The entire process -- from triggering to publishing -- requires zero human intervention. You wake up, open Notion or Obsidian (or Teams or Slack), and your daily AI briefing is already there.
 
-**Custom Brief** extends this with on-demand deep research: pick any topic, and 5 parallel research agents investigate it from different angles (breaking news, technical analysis, industry impact, trends, and policy). Results publish to Notion, Teams, and/or Slack -- or just print to your terminal.
+**Custom Brief** extends this with on-demand deep research: pick any topic, and 5 parallel research agents investigate it from different angles (breaking news, technical analysis, industry impact, trends, and policy). Results publish to Notion, Obsidian, Teams, and/or Slack -- or just print to your terminal.
 
 ### Why it exists
 
@@ -74,6 +75,7 @@ flowchart TD
     H -->|Creates page| I[Notion Database]
 
     D -->|Step 4: Write card| J2[logs/YYYY-MM-DD-card.json]
+    D -->|Step 5: Write obsidian md| J3[logs/YYYY-MM-DD-obsidian.md]
 
     B1 -->|If Teams webhook set| T[notify-teams.sh]
     B2 -->|If Teams webhook set| T2[notify-teams.ps1]
@@ -87,6 +89,11 @@ flowchart TD
     S2 -->|Convert + POST| SV
     SV --> SW[Slack Channel]
 
+    B1 -->|If Obsidian vault set| OB1[publish-obsidian.sh]
+    B2 -->|If Obsidian vault set| OB2[publish-obsidian.ps1]
+    OB1 -->|Copy + create topics| OBV[Obsidian Vault]
+    OB2 -->|Copy + create topics| OBV
+
     B1 -->|Logs output| J[logs/YYYY-MM-DD.log]
     B2 -->|Logs output| J
     J -->|Auto-cleanup| K[Delete logs older than 30 days]
@@ -98,9 +105,11 @@ flowchart TD
 2. The script reads the prompt from `prompt.md` and passes it to the selected AI CLI engine in headless mode.
 3. The AI engine executes the prompt as an agentic task -- performing web searches, compiling results, and calling the Notion MCP tool.
 4. Notion receives the finished briefing as a new database page.
-5. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which validates and POSTs the pre-built `logs/YYYY-MM-DD-card.json` file (written by Claude in Step 4) to the configured Teams webhook.
-6. If the `AI_BRIEFING_SLACK_WEBHOOK` environment variable is set, the entry point script calls `notify-slack.sh` / `notify-slack.ps1`, which converts the Teams card to Slack Block Kit format and POSTs it to the configured Slack webhook.
-7. Logs are written to a date-stamped file and automatically pruned after 30 days.
+5. Claude also writes an Obsidian-formatted markdown file with `[[wikilinks]]` for graph visualization.
+6. If the `AI_BRIEFING_TEAMS_WEBHOOK` environment variable is set, the entry point script calls `notify-teams.sh` / `notify-teams.ps1`, which validates and POSTs the pre-built `logs/YYYY-MM-DD-card.json` file (written by Claude in Step 4) to the configured Teams webhook.
+7. If the `AI_BRIEFING_SLACK_WEBHOOK` environment variable is set, the entry point script calls `notify-slack.sh` / `notify-slack.ps1`, which converts the Teams card to Slack Block Kit format and POSTs it to the configured Slack webhook.
+8. If the `AI_BRIEFING_OBSIDIAN_VAULT` environment variable is set, the entry point script calls `publish-obsidian.sh` / `publish-obsidian.ps1`, which copies the briefing to the vault and creates topic stub pages for graph nodes.
+9. Logs are written to a date-stamped file and automatically pruned after 30 days.
 
 ---
 
@@ -424,6 +433,9 @@ export AI_BRIEFING_TEAMS_WEBHOOK="https://first-teams-webhook"
 
 # Slack
 export AI_BRIEFING_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../..."
+
+# Obsidian vault
+export AI_BRIEFING_OBSIDIAN_VAULT="/path/to/your/obsidian/vault"
 ```
 
 **Windows (PowerShell)**
@@ -431,6 +443,7 @@ export AI_BRIEFING_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../...
 ```powershell
 [Environment]::SetEnvironmentVariable("AI_BRIEFING_TEAMS_WEBHOOK", "https://first-teams-webhook", "User")
 [Environment]::SetEnvironmentVariable("AI_BRIEFING_SLACK_WEBHOOK", "https://hooks.slack.com/services/T.../B.../...", "User")
+[Environment]::SetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "C:\path\to\your\obsidian\vault", "User")
 ```
 
 ### Multiple Webhooks and `--all` / `-All`
@@ -487,7 +500,7 @@ In addition to the daily automated briefing, you can run a deep research briefin
 flowchart LR
     subgraph "Input"
         A["--topic 'AI in healthcare'"]
-        B["--notion --teams --slack"]
+        B["--notion --obsidian --teams --slack"]
     end
     A --> C[custom-brief.sh / .ps1]
     B --> C
@@ -495,6 +508,7 @@ flowchart LR
     D --> E[Structured Briefing]
     E --> F[Terminal Output]
     E -->|optional| G[Notion]
+    E -->|optional| G2[Obsidian Vault + Graph]
     E -->|optional| H[Teams]
     E -->|optional| I[Slack]
 ```
@@ -507,10 +521,13 @@ flowchart LR
 
 ```bash
 # Full research with all destinations
-./custom-brief.sh --topic "AI in healthcare" --notion --teams --slack
+./custom-brief.sh --topic "AI in healthcare" --notion --obsidian --teams --slack
 
-# Terminal + Notion only
-./custom-brief.sh -t "quantum computing" -n
+# Terminal + Notion + Obsidian
+./custom-brief.sh -t "quantum computing" -n -o
+
+# Obsidian only (for graph visualization)
+./custom-brief.sh -t "AI coding tools" -o
 
 # Use a specific engine
 ./custom-brief.sh --cli codex --topic "AI safety" --notion
@@ -519,13 +536,13 @@ flowchart LR
 ./custom-brief.sh
 
 # PowerShell
-.\custom-brief.ps1 -Topic "AI regulation EU" -Notion -Teams
+.\custom-brief.ps1 -Topic "AI regulation EU" -Notion -Obsidian -Teams
 
 # PowerShell with engine override
 .\custom-brief.ps1 -Cli gemini -Topic "AI regulation EU" -Notion
 
 # Make
-make custom-brief T="open source LLMs" NOTION=1 TEAMS=1
+make custom-brief T="open source LLMs" NOTION=1 OBSIDIAN=1 TEAMS=1
 make custom-brief T="AI safety" CLI=codex NOTION=1
 ```
 
@@ -631,7 +648,7 @@ Logs older than 30 days are automatically deleted at the end of each run on both
 
 ## Tests
 
-We have several test suites, with 247 non-blocking tests that verify syntax, structure, arg handling, template substitution, card JSON, notification error paths, and cross-platform portability. No external services are called.
+We have several test suites, with 201 non-blocking tests that verify syntax, structure, arg handling, template substitution, card JSON, notification error paths, Obsidian publishing, and cross-platform portability. No external services are called.
 
 <p align="center">
   <img src="img/tests.png" alt="Tests Overview" width="100%">
@@ -773,7 +790,7 @@ ai-news-briefing/
 │   └── custom-brief.md          # Claude Code skill: custom topic briefing
 ├── com.ainews.briefing.plist    # macOS launchd schedule definition
 ├── install-task.ps1             # Windows Task Scheduler installer
-├── tests/                       # 247 non-blocking tests
+├── tests/                       # 201 non-blocking tests
 │   ├── run-all.sh               # Bash test runner
 │   ├── test-custom-brief.sh     # Custom brief tests
 │   ├── test-daily-brief.sh      # Daily briefing tests

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,6 +10,7 @@ Complete setup instructions for the AI News Briefing system, covering both the d
 |---|---|---|
 | **At least one AI CLI** | Both | Any of: **Claude Code** (`claude`), **Codex** (`codex`), **Gemini** (`gemini`), or **Copilot** (`copilot`). Multiple can be installed for fallback. |
 | **Notion MCP** | Both (optional) | The Notion MCP server configured in your AI CLI's MCP settings |
+| **Obsidian** | Both (optional) | [obsidian.md](https://obsidian.md) — local vault path set via `AI_BRIEFING_OBSIDIAN_VAULT` |
 | **WebSearch tool** | Both | Built into most AI CLIs (no extra setup) |
 | **Python 3.x** | Slack delivery | Required for `teams-to-slack.py` conversion |
 | **GNU Make** | Optional | For `make run`, `make custom-brief`, etc. (`winget install GnuWin32.Make` on Windows) |
@@ -127,6 +128,36 @@ Separate multiple URLs with semicolons:
 export AI_BRIEFING_TEAMS_WEBHOOK="https://webhook-1;https://webhook-2"
 ```
 
+### Obsidian Vault
+
+[Obsidian](https://obsidian.md) is a local-first markdown editor with a powerful graph view. Briefings published to Obsidian use `[[wikilinks]]` to create topic connections visible in the graph.
+
+1. Install Obsidian and create or open a vault.
+
+2. Set the vault path:
+
+**macOS/Linux:**
+```bash
+export AI_BRIEFING_OBSIDIAN_VAULT="/path/to/your/vault"
+```
+
+**Windows (persistent):**
+```powershell
+[Environment]::SetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "C:\path\to\your\vault", "User")
+```
+
+3. The system creates two subdirectories in your vault:
+   - `AI-News-Briefings/` — daily and custom briefing pages
+   - `Topics/` — stub pages for each topic (graph nodes)
+
+4. Test connectivity:
+
+```bash
+bash scripts/test-obsidian.sh
+```
+
+5. Obsidian's graph view will show briefings connected to topic nodes. Open the graph view (`Ctrl/Cmd + G`) to visualize topic relationships across all your briefings.
+
 ---
 
 ## 5. Schedule the Daily Briefing
@@ -182,6 +213,12 @@ make check   # Verifies at least one AI CLI is available
 bash scripts/test-notion.sh
 ```
 
+### Test Obsidian connectivity
+
+```bash
+bash scripts/test-obsidian.sh
+```
+
 ### Manual test run
 
 ```bash
@@ -218,7 +255,10 @@ flowchart TD
 |---|---|
 | Run daily briefing | `make run` or `bash briefing.sh` |
 | Run custom brief | `make custom-brief T="topic" NOTION=1` or `bash custom-brief.sh --topic "topic" --notion` |
+| Run custom brief with Obsidian | `make custom-brief T="topic" OBSIDIAN=1` or `bash custom-brief.sh --topic "topic" --obsidian` |
 | Check status | `make status` |
 | View today's log | `make tail` |
+| Test Notion connectivity | `bash scripts/test-notion.sh` |
+| Test Obsidian connectivity | `bash scripts/test-obsidian.sh` |
 | Test Teams delivery | `bash scripts/notify-teams.sh --all --card-file logs/YYYY-MM-DD-card.json` |
 | Test Slack delivery | `bash scripts/notify-slack.sh --all --card-file logs/YYYY-MM-DD-card.json` |

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,6 +1,6 @@
 # Test Suite
 
-247 non-blocking tests across bash and PowerShell covering the daily briefing, custom brief, notification pipeline, and cross-platform portability. No external services are called -- no Claude API, no webhooks, no Notion.
+247 non-blocking tests across bash and PowerShell covering the daily briefing, custom brief, notification pipeline, Obsidian publishing, and cross-platform portability. No external services are called -- no Claude API, no webhooks, no Notion, no vault writes.
 
 ---
 
@@ -13,6 +13,7 @@ flowchart TD
         R --> T2["test-daily-brief.sh"]
         R --> T3["test-notifications.sh"]
         R --> T4["test-portability.sh"]
+        R --> T5["test-obsidian.sh"]
     end
 
     subgraph "PowerShell Test Suite"
@@ -39,6 +40,11 @@ flowchart TD
         T4 --> P2["awk/date portability"]
         T4 --> P3["-f not -x checks"]
         T4 --> P4["ANSI color safety"]
+
+        T5 --> O1["Publish script structure"]
+        T5 --> O2["Wikilink extraction"]
+        T5 --> O3["Error handling"]
+        T5 --> O4["Vault simulation"]
 
         PS --> C1
         PS --> C2
@@ -82,7 +88,7 @@ There is no Make target for tests (tests are not part of the daily pipeline). Ru
 
 ## Test Suites
 
-### test-custom-brief.sh (37 tests)
+### test-custom-brief.sh (48 tests)
 
 Tests for the custom topic deep research feature.
 
@@ -95,6 +101,7 @@ flowchart LR
         D --> E["Prompt template"]
         E --> F["Template substitution"]
         F --> G["Interactive skill"]
+        G --> H["Obsidian integration"]
     end
 ```
 
@@ -102,13 +109,14 @@ flowchart LR
 |---|---|---|
 | File existence | 4 | `custom-brief.sh`, `prompt-custom-brief.md`, `commands/custom-brief.md` exist |
 | Bash syntax | 1 | `bash -n` passes |
-| Help flag | 6 | `--help` and `-h` print usage with all flags documented |
+| Help flag | 7 | `--help` and `-h` print usage with all flags documented (including `--obsidian`) |
 | Arg validation | 2 | Missing `--topic` value errors, unknown options error |
-| Prompt template | 12 | All `{{}}` placeholders, Phase 1-3, Agent 1-5, card template, citation requirement |
-| Template substitution | 5 | awk gsub replaces all placeholders, handles special chars, no leftover `{{}}` |
+| Prompt template | 13 | All `{{}}` placeholders (including `{{PUBLISH_OBSIDIAN}}`), Phase 1-3, Agent 1-5, card template, citation requirement |
+| Template substitution | 6 | awk gsub replaces all placeholders (including Obsidian), handles special chars, no leftover `{{}}` |
 | Interactive skill | 7 | Frontmatter, steps, agents, Notion MCP, data_source_id, quality checklist |
+| Obsidian integration | 8 | `PUBLISH_OBSIDIAN` in script, flag handling, publish script call, template wikilinks, skill reference |
 
-### test-daily-brief.sh (56 tests)
+### test-daily-brief.sh (80 tests)
 
 Tests for the existing daily automated briefing pipeline.
 
@@ -122,6 +130,7 @@ flowchart LR
         E --> F["Skill structure"]
         F --> G["Entry scripts"]
         G --> H["Dedup file"]
+        H --> I["Obsidian integration"]
     end
 ```
 
@@ -129,15 +138,22 @@ flowchart LR
 |---|---|---|
 | File existence | 5 | All pipeline files: `briefing.sh`, `briefing.ps1`, `prompt.md`, `install-task.ps1`, skill |
 | Bash syntax | 1 | `bash -n` on `briefing.sh` |
-| Prompt structure | 11 | Steps 0-5, data_source_id, dedup file, Notion MCP tools, card template |
+| Prompt structure | 12 | Steps 0-6, data_source_id, dedup file, Notion MCP tools, card template |
 | Topic coverage | 9 | All 9 topic areas present in prompt |
 | Changelog URLs | 8 | All 8 provider changelog URLs present |
 | Skill structure | 6 | Frontmatter, steps, Notion create, dedup reference |
 | Entry scripts (bash) | 7 | Strict mode, prompt.md read, Claude invocation, Teams/Slack notify, CLAUDECODE clear |
 | Entry scripts (PS1) | 6 | Same checks on `briefing.ps1` |
 | Dedup file | 3 | `covered-stories.txt` exists, has entries, correct `YYYY-MM-DD \| headline` format |
+| Obsidian (prompt) | 4 | Obsidian mention, obsidian.md output, `[[wikilinks]]`, YAML frontmatter |
+| Obsidian (briefing.sh) | 3 | Publisher call, vault env check, obsidian.md reference |
+| Obsidian (briefing.ps1) | 3 | Publisher call, vault env check, obsidian.md reference |
+| Obsidian scripts | 6 | publish-obsidian.sh/.ps1, test-obsidian.sh/.ps1 existence and executability |
+| Obsidian syntax | 2 | `bash -n` on publish and test scripts |
+| Obsidian structure | 6 | Strict mode, subdirectories, wikilinks, topic type, vault env var |
+| Obsidian skill | 1 | Obsidian mentioned in daily skill file |
 
-### test-notifications.sh (37 tests)
+### test-notifications.sh (17 tests)
 
 Tests for the Teams and Slack notification pipeline.
 
@@ -163,6 +179,32 @@ flowchart LR
 | Converter | 6 | Processes latest card, output is valid JSON, Slack header/divider/sections/button |
 | notify-teams.sh args | 3 | Errors on missing webhook, unknown option, missing card file |
 | notify-slack.sh args | 3 | Same error handling checks |
+
+### test-obsidian.sh (30 tests)
+
+Tests for the Obsidian publishing pipeline with vault simulation.
+
+```mermaid
+flowchart LR
+    subgraph "test-obsidian.sh"
+        A["File existence"] --> B["Bash syntax"]
+        B --> C["Publish structure"]
+        C --> D["Wikilink logic"]
+        D --> E["Error handling"]
+        E --> F["Test script structure"]
+        F --> G["Vault simulation"]
+    end
+```
+
+| Category | Tests | What it verifies |
+|---|---|---|
+| File existence | 6 | `publish-obsidian.sh/.ps1`, `test-obsidian.sh/.ps1` existence and executability |
+| Bash syntax | 2 | `bash -n` on both bash scripts |
+| Publish structure | 6 | Strict mode, subdirectories, vault env, mkdir, cp |
+| Wikilink logic | 3 | grep extraction, `[[` pattern, topic type YAML |
+| Error handling | 3 | exit on error, missing file error, missing vault error |
+| Test script structure | 3 | Vault env check, .obsidian config check, writability check |
+| Vault simulation | 7 | Creates temp vault, publishes markdown, verifies directories, topic stubs, frontmatter, idempotent re-run |
 
 ### test-portability.sh (26 tests)
 
@@ -249,7 +291,7 @@ The `run-all.sh` runner displays an ASCII art banner and an aggregate result:
    |   |    / \  |_ _| | \ | | _____      _____  | __ ) _ __(_) ___ / _| |   |
    ...
   =====================================================
-    ALL 4 SUITES PASSED
+    ALL 5 SUITES PASSED
   =====================================================
 ```
 
@@ -257,7 +299,7 @@ The `run-all.sh` runner displays an ASCII art banner and an aggregate result:
 
 ## Design Principles
 
-- **Non-blocking.** No test calls Claude, Notion, Teams, Slack, or any external service. Tests validate structure, syntax, and contracts -- not runtime behavior.
+- **Non-blocking.** No test calls Claude, Notion, Teams, Slack, or any external service. Obsidian tests use temp directories -- no real vault needed. Tests validate structure, syntax, and contracts -- not runtime behavior.
 - **Tailored to pass.** Tests verify existing working code. They check what IS there, not hypothetical requirements.
 - **Cross-platform.** Bash tests run on macOS, Linux, and Windows Git Bash. PowerShell tests run on Windows. Both cover the same code from different angles.
 - **No test framework.** Pure bash and PowerShell with simple `pass()`/`fail()` helpers. No dependencies to install.
@@ -270,9 +312,10 @@ The `run-all.sh` runner displays an ASCII art banner and an aggregate result:
 ```
 tests/
   run-all.sh               # Bash test runner (runs all test-*.sh suites)
-  test-custom-brief.sh     # Custom brief: args, template, prompt, skill
-  test-daily-brief.sh      # Daily brief: prompt, topics, changelogs, scripts
+  test-custom-brief.sh     # Custom brief: args, template, prompt, skill, Obsidian
+  test-daily-brief.sh      # Daily brief: prompt, topics, changelogs, scripts, Obsidian
   test-notifications.sh    # Notifications: cards, converter, error paths
+  test-obsidian.sh         # Obsidian: publish script, wikilinks, vault simulation
   test-portability.sh      # Cross-platform: bash compat, awk, date, colors
   test-all.ps1             # PowerShell suite (all categories in one file)
 ```

--- a/briefing.ps1
+++ b/briefing.ps1
@@ -223,6 +223,27 @@ if ($Success) {
             Write-Log "Slack notification failed: $_"
         }
     }
+
+    # Publish to Obsidian vault if configured
+    $obsidianScript = Join-Path $ScriptDir "scripts\publish-obsidian.ps1"
+    $obsidianFile = Join-Path $LogDir "$Date-obsidian.md"
+    $obsidianVault = $env:AI_BRIEFING_OBSIDIAN_VAULT
+    if (-not $obsidianVault) {
+        $obsidianVault = [Environment]::GetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "User")
+    }
+    if ((Test-Path $obsidianScript) -and $obsidianVault) {
+        if (Test-Path $obsidianFile) {
+            Write-Log "Publishing to Obsidian vault..."
+            try {
+                & $obsidianScript -File $obsidianFile
+                Write-Log "Obsidian publish complete."
+            } catch {
+                Write-Log "Obsidian publish failed: $_"
+            }
+        } else {
+            Write-Log "Obsidian skipped -- markdown file not found."
+        }
+    }
 } else {
     Write-Log "Briefing FAILED -- all engines exhausted or selected engine failed."
 }

--- a/briefing.sh
+++ b/briefing.sh
@@ -232,6 +232,22 @@ if $SUCCESS; then
       write_log "Slack notification failed."
     fi
   fi
+
+  # Publish to Obsidian vault if configured
+  OBSIDIAN_SCRIPT="$SCRIPT_DIR/scripts/publish-obsidian.sh"
+  OBSIDIAN_FILE="$LOG_DIR/$DATE-obsidian.md"
+  if [[ -f "$OBSIDIAN_SCRIPT" && -n "${AI_BRIEFING_OBSIDIAN_VAULT:-}" ]]; then
+    if [[ -f "$OBSIDIAN_FILE" ]]; then
+      echo "[$DATE $(date +%H:%M:%S)] Publishing to Obsidian vault..." >> "$LOG_FILE"
+      if bash "$OBSIDIAN_SCRIPT" --file "$OBSIDIAN_FILE"; then
+        echo "[$DATE $(date +%H:%M:%S)] Obsidian publish complete." >> "$LOG_FILE"
+      else
+        echo "[$DATE $(date +%H:%M:%S)] Obsidian publish failed." >> "$LOG_FILE"
+      fi
+    else
+      echo "[$DATE $(date +%H:%M:%S)] Obsidian skipped -- markdown file not found." >> "$LOG_FILE"
+    fi
+  fi
 else
   write_log "Briefing FAILED -- all engines exhausted or selected engine failed."
 fi

--- a/commands/ai-news-briefing.md
+++ b/commands/ai-news-briefing.md
@@ -1,5 +1,5 @@
 ---
-description: Search for today's latest AI news and create/update a comprehensive briefing in Notion
+description: Search for today's latest AI news and create/update a comprehensive briefing in Notion, with optional Obsidian vault publishing for graph visualization
 ---
 
 You are an AI news research agent. Search for TODAY's latest AI news and create a comprehensive briefing in Notion.
@@ -208,7 +208,20 @@ Use the `Write` tool to save the file. Use the template below, replacing the pla
 - Use short display names (publication name only, not full article titles).
 - If there are too many sources to fit, prioritize primary/original sources over aggregators.
 
-## Step 5: Update Covered Stories List
+## Step 5: Generate Obsidian Markdown
+
+Write an Obsidian-formatted version of the briefing to `logs/YYYY-MM-DD-obsidian.md`. This file is published to the user's Obsidian vault by the calling script for graph visualization.
+
+**Key rules:**
+- Include YAML frontmatter with date, type, topics list, and tags.
+- Wrap topic names in `[[double brackets]]` (e.g., `## [[Claude Code]] / [[Anthropic]]`) so Obsidian's graph view shows connections.
+- Include a "Related topics" line: `> Related topics: [[Claude Code]] · [[OpenAI]] · [[AI Coding IDEs]] · ...`
+- Use standard Markdown (not Notion-flavored). Standard `|` tables, `---` dividers, `> ` blockquotes.
+- Only include sections with actual news content.
+
+The calling script handles copying to the vault and creating topic stub pages. Do NOT write to the vault directly.
+
+## Step 6: Update Covered Stories List
 
 After generating the briefing and card, append today's story headlines to `logs/covered-stories.txt`. This file is used for deduplication in future runs.
 

--- a/commands/custom-brief.md
+++ b/commands/custom-brief.md
@@ -1,5 +1,5 @@
 ---
-description: Deep-research a specific topic and produce a comprehensive news-focused briefing with optional Notion/Teams/Slack publishing
+description: Deep-research a specific topic and produce a comprehensive news-focused briefing with optional Notion/Obsidian/Teams/Slack publishing
 ---
 
 You are a deep research agent specializing in AI and technology news intelligence. The user wants a comprehensive, multi-angle news briefing on a specific topic.
@@ -10,11 +10,12 @@ Ask the user (if not already provided):
 1. **Topic** — What topic should the briefing cover?
 2. **Destinations** — Where should the results be published?
    - Notion (creates a page in the AI Daily Briefing database)
+   - Obsidian (writes a markdown file with [[wikilinks]] to the user's vault for graph visualization)
    - Teams (sends an Adaptive Card summary)
    - Slack (sends a Block Kit summary)
    - CLI output is always included.
 
-Record the answers. You need: TOPIC, PUBLISH_NOTION (true/false), PUBLISH_TEAMS (true/false), PUBLISH_SLACK (true/false).
+Record the answers. You need: TOPIC, PUBLISH_NOTION (true/false), PUBLISH_OBSIDIAN (true/false), PUBLISH_TEAMS (true/false), PUBLISH_SLACK (true/false).
 
 ---
 
@@ -127,6 +128,20 @@ If PUBLISH_NOTION is true:
 
 ---
 
+## Step 4b: Publish to Obsidian (if requested)
+
+If PUBLISH_OBSIDIAN is true:
+
+Write an Obsidian-formatted markdown file to `logs/custom-[TIMESTAMP]-obsidian.md` with:
+- YAML frontmatter (date, type, topic, tags)
+- `[[wikilinks]]` wrapping topic/company/technology names in headings and body text
+- A "Related topics" line at the top linking to key topic pages: `> Related topics: [[Topic 1]] · [[Topic 2]]`
+- Standard Markdown tables, dividers, blockquotes
+
+The calling script handles copying the file to the Obsidian vault and creating topic stub pages for the graph view. Do NOT write directly to the vault.
+
+---
+
 ## Step 5: Generate Card JSON (if Teams or Slack requested)
 
 If PUBLISH_TEAMS or PUBLISH_SLACK is true:
@@ -153,4 +168,5 @@ Before finishing, verify:
 - [ ] Key Trends table is present
 - [ ] Sources list includes every URL cited
 - [ ] Notion page created (if requested)
+- [ ] Obsidian markdown written with [[wikilinks]] (if requested)
 - [ ] Card JSON written and valid (if requested)

--- a/custom-brief.ps1
+++ b/custom-brief.ps1
@@ -5,7 +5,7 @@
     Deep-research a topic and produce a comprehensive news briefing.
 .DESCRIPTION
     Uses an AI CLI engine in headless mode to conduct multi-agent deep research
-    on a user-defined topic, then optionally publishes to Notion, Teams, and/or Slack.
+    on a user-defined topic, then optionally publishes to Notion, Obsidian, Teams, and/or Slack.
     Supports Claude Code, Codex, Gemini, and GitHub Copilot.
 .PARAMETER Topic
     The topic to research. If omitted, enters interactive mode.
@@ -13,14 +13,16 @@
     AI engine: claude, codex, gemini, copilot. Default: AI_BRIEFING_CLI env or claude.
 .PARAMETER Notion
     Publish the briefing to Notion.
+.PARAMETER Obsidian
+    Publish the briefing to an Obsidian vault (requires AI_BRIEFING_OBSIDIAN_VAULT env var).
 .PARAMETER Teams
     Send a summary card to Microsoft Teams.
 .PARAMETER Slack
     Send a summary card to Slack.
 .EXAMPLE
-    .\custom-brief.ps1 -Topic "AI in healthcare" -Cli codex -Notion -Teams
+    .\custom-brief.ps1 -Topic "AI in healthcare" -Cli codex -Notion -Obsidian -Teams
 .EXAMPLE
-    .\custom-brief.ps1 -Topic "quantum computing" -Notion
+    .\custom-brief.ps1 -Topic "quantum computing" -Notion -Obsidian
 .EXAMPLE
     .\custom-brief.ps1   # interactive mode
 #>
@@ -30,6 +32,7 @@ param(
     [ValidateSet("claude", "codex", "gemini", "copilot", "")]
     [string]$Cli = "",
     [switch]$Notion,
+    [switch]$Obsidian,
     [switch]$Teams,
     [switch]$Slack
 )
@@ -189,7 +192,6 @@ if (-not $Topic) {
         exit 1
     }
     Write-Host ""
-
     # AI Engine
     Write-Host "  --- AI Engine ---------------------------------------------" -ForegroundColor DarkGray
     $idx = 0
@@ -245,9 +247,11 @@ if (-not $Topic) {
 
     # Publish destinations
     Write-Host "  --- Publish -----------------------------------------------" -ForegroundColor DarkGray
-    $yn = Read-Host "    Notion? [y/N]"
+    $yn = Read-Host "    Notion?   [y/N]"
     if ($yn -match "^[Yy]") { $Notion = [switch]::new($true) }
-    $yn = Read-Host "    Teams?  [y/N]"
+    $yn = Read-Host "    Obsidian? [y/N]"
+    if ($yn -match "^[Yy]") { $Obsidian = [switch]::new($true) }
+    $yn = Read-Host "    Teams?    [y/N]"
     if ($yn -match "^[Yy]") { $Teams = [switch]::new($true) }
     $yn = Read-Host "    Slack?  [y/N]"
     if ($yn -match "^[Yy]") { $Slack = [switch]::new($true) }
@@ -268,6 +272,7 @@ if (-not $EngineBinary) {
 
 # -- Derive flags ----------------------------------------------
 $PublishNotion = if ($Notion) { "true" } else { "false" }
+$PublishObsidian = if ($Obsidian) { "true" } else { "false" }
 $PublishTeamsSlack = if ($Teams -or $Slack) { "true" } else { "false" }
 $PublishTeams = if ($Teams) { "true" } else { "false" }
 $PublishSlack = if ($Slack) { "true" } else { "false" }
@@ -283,6 +288,7 @@ $Prompt = $PromptTemplate.
     Replace('{{DATE}}', $Date).
     Replace('{{TIMESTAMP}}', $Timestamp).
     Replace('{{PUBLISH_NOTION}}', $PublishNotion).
+    Replace('{{PUBLISH_OBSIDIAN}}', $PublishObsidian).
     Replace('{{PUBLISH_TEAMS_SLACK}}', $PublishTeamsSlack)
 
 # -- Styled boolean label --------------------------------------
@@ -305,6 +311,7 @@ Write-Host ""
 Write-Host "  Topic     " -NoNewline; Write-Host "$Topic"
 Write-Host "  Engine    " -NoNewline; Write-Host "$(Get-CliDisplayName $Cli)" -NoNewline; Write-Host " ($EngineBinary)" -ForegroundColor DarkGray
 Write-Flag "Notion" $PublishNotion
+Write-Flag "Obsidian" $PublishObsidianFlag
 Write-Flag "Teams" $PublishTeams
 Write-Flag "Slack" $PublishSlack
 Write-Host "  Log       " -NoNewline -ForegroundColor DarkGray; Write-Host "$LogFile" -ForegroundColor DarkGray
@@ -323,7 +330,7 @@ function Write-Log {
 }
 
 Write-Log "Custom Brief -- Topic: $Topic"
-Write-Log "Engine=$Cli Notion=$PublishNotion Teams=$PublishTeams Slack=$PublishSlack"
+Write-Log "Engine=$Cli Notion=$PublishNotion Obsidian=$PublishObsidian Teams=$PublishTeams Slack=$PublishSlack"
 
 # -- Run engine ------------------------------------------------
 try {
@@ -398,6 +405,41 @@ try {
             Write-Host "  Slack     " -ForegroundColor Yellow -NoNewline
             Write-Host "skipped " -NoNewline
             Write-Host "(webhook not set)" -ForegroundColor DarkGray
+        }
+    }
+
+    # -- Post-processing: Obsidian publishing ---------------
+    if ($Obsidian) {
+        $obsidianScript = Join-Path $ScriptDir "scripts\publish-obsidian.ps1"
+        $obsidianFile = Join-Path $LogDir "custom-$Timestamp-obsidian.md"
+        $obsidianVault = $env:AI_BRIEFING_OBSIDIAN_VAULT
+        if (-not $obsidianVault) {
+            $obsidianVault = [Environment]::GetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "User")
+        }
+        if ((Test-Path $obsidianScript) -and $obsidianVault) {
+            if (Test-Path $obsidianFile) {
+                Write-Host "  Publishing to Obsidian..." -ForegroundColor DarkGray
+                Write-Log "Publishing to Obsidian vault..."
+                try {
+                    & $obsidianScript -File $obsidianFile
+                    Write-Log "Obsidian publish complete."
+                    Write-Host "  Obsidian  " -ForegroundColor Green -NoNewline
+                    Write-Host "published"
+                } catch {
+                    Write-Log "Obsidian publish failed: $_"
+                    Write-Host "  Obsidian  " -ForegroundColor Red -NoNewline
+                    Write-Host "failed"
+                }
+            } else {
+                Write-Host "  Obsidian  " -ForegroundColor Yellow -NoNewline
+                Write-Host "skipped " -NoNewline
+                Write-Host "(no markdown file)" -ForegroundColor DarkGray
+                Write-Log "Obsidian skipped -- markdown file not found."
+            }
+        } else {
+            Write-Host "  Obsidian  " -ForegroundColor Yellow -NoNewline
+            Write-Host "skipped " -NoNewline
+            Write-Host "(vault not set)" -ForegroundColor DarkGray
         }
     }
 } catch {

--- a/custom-brief.sh
+++ b/custom-brief.sh
@@ -116,6 +116,7 @@ run_engine() {
 TOPIC=""
 CLI_ENGINE=""
 PUBLISH_NOTION=false
+PUBLISH_OBSIDIAN=false
 PUBLISH_TEAMS=false
 PUBLISH_SLACK=false
 
@@ -130,6 +131,7 @@ Options:
   --topic, -t TEXT        Topic to research (required in non-interactive mode)
   --cli, -c ENGINE        AI engine: claude, codex, gemini, copilot
   --notion, -n            Publish to Notion
+  --obsidian, -o          Publish to Obsidian vault (requires AI_BRIEFING_OBSIDIAN_VAULT)
   --teams                 Publish to Microsoft Teams
   --slack                 Publish to Slack
   --help, -h              Show this help
@@ -141,8 +143,8 @@ Environment:
 If no arguments are given, enters interactive mode.
 
 Examples:
-  ./custom-brief.sh --topic "AI in healthcare" --cli codex --notion --teams
-  ./custom-brief.sh -t "quantum computing" -c gemini -n
+  ./custom-brief.sh --topic "AI in healthcare" --cli codex --notion --obsidian --teams
+  ./custom-brief.sh -t "quantum computing" -c gemini -n -o
   ./custom-brief.sh   # interactive mode
 EOF
 }
@@ -157,6 +159,8 @@ while [[ $# -gt 0 ]]; do
       CLI_ENGINE="$2"; shift 2 ;;
     --notion|-n)
       PUBLISH_NOTION=true; shift ;;
+    --obsidian|-o)
+      PUBLISH_OBSIDIAN=true; shift ;;
     --teams)
       PUBLISH_TEAMS=true; shift ;;
     --slack)
@@ -199,7 +203,6 @@ if [[ -z "$TOPIC" ]]; then
     exit 1
   fi
   echo ""
-
   # AI Engine
   echo -e "  ${DIM}--- AI Engine ---------------------------------------------${RESET}"
   idx=0
@@ -252,9 +255,11 @@ if [[ -z "$TOPIC" ]]; then
 
   # Publish destinations
   echo -e "  ${DIM}--- Publish -----------------------------------------------${RESET}"
-  read -rp "    Notion? [y/N]: " yn
+  read -rp "    Notion?   [y/N]: " yn
   [[ "$yn" =~ ^[Yy] ]] && PUBLISH_NOTION=true
-  read -rp "    Teams?  [y/N]: " yn
+  read -rp "    Obsidian? [y/N]: " yn
+  [[ "$yn" =~ ^[Yy] ]] && PUBLISH_OBSIDIAN=true
+  read -rp "    Teams?    [y/N]: " yn
   [[ "$yn" =~ ^[Yy] ]] && PUBLISH_TEAMS=true
   read -rp "    Slack?  [y/N]: " yn
   [[ "$yn" =~ ^[Yy] ]] && PUBLISH_SLACK=true
@@ -288,12 +293,14 @@ PROMPT="$(awk \
   -v date="$DATE" \
   -v ts="$TIMESTAMP" \
   -v notion="$PUBLISH_NOTION" \
+  -v obsidian="$PUBLISH_OBSIDIAN" \
   -v tslack="$PUBLISH_TEAMS_SLACK" \
   '{
     gsub(/\{\{TOPIC\}\}/, topic)
     gsub(/\{\{DATE\}\}/, date)
     gsub(/\{\{TIMESTAMP\}\}/, ts)
     gsub(/\{\{PUBLISH_NOTION\}\}/, notion)
+    gsub(/\{\{PUBLISH_OBSIDIAN\}\}/, obsidian)
     gsub(/\{\{PUBLISH_TEAMS_SLACK\}\}/, tslack)
     print
   }' <<< "$PROMPT_TEMPLATE")"
@@ -314,6 +321,7 @@ echo ""
 echo -e "  ${BOLD}Topic${RESET}     $TOPIC"
 echo -e "  ${BOLD}Engine${RESET}    $(cli_display_name "$CLI_ENGINE") ${DIM}($ENGINE_BINARY)${RESET}"
 echo -e "  ${BOLD}Notion${RESET}    $(flag_label "$PUBLISH_NOTION")"
+echo -e "  ${BOLD}Obsidian${RESET}  $(flag_label "$PUBLISH_OBSIDIAN")"
 echo -e "  ${BOLD}Teams${RESET}     $(flag_label "$PUBLISH_TEAMS")"
 echo -e "  ${BOLD}Slack${RESET}     $(flag_label "$PUBLISH_SLACK")"
 echo -e "  ${DIM}Log${RESET}       ${DIM}$LOG_FILE${RESET}"
@@ -327,7 +335,7 @@ echo ""
 # -- Log header ------------------------------------------------
 {
   echo "[$DATE $(date +%H:%M:%S)] Custom Brief -- Topic: $TOPIC"
-  echo "[$DATE $(date +%H:%M:%S)] Engine=$CLI_ENGINE Notion=$PUBLISH_NOTION Teams=$PUBLISH_TEAMS Slack=$PUBLISH_SLACK"
+  echo "[$DATE $(date +%H:%M:%S)] Engine=$CLI_ENGINE Notion=$PUBLISH_NOTION Obsidian=$PUBLISH_OBSIDIAN Teams=$PUBLISH_TEAMS Slack=$PUBLISH_SLACK"
 } >> "$LOG_FILE"
 
 # -- Run engine ------------------------------------------------
@@ -392,6 +400,30 @@ if [[ "$PUBLISH_SLACK" == "true" ]]; then
     fi
   else
     echo -e "  ${YELLOW}Slack${RESET}     skipped ${DIM}(webhook not set)${RESET}" >&2
+  fi
+fi
+
+# -- Post-processing: Obsidian publishing ------------------
+if [[ "$PUBLISH_OBSIDIAN" == "true" ]]; then
+  OBSIDIAN_SCRIPT="$SCRIPT_DIR/scripts/publish-obsidian.sh"
+  OBSIDIAN_FILE="$LOG_DIR/custom-$TIMESTAMP-obsidian.md"
+  if [[ -f "$OBSIDIAN_SCRIPT" && -n "${AI_BRIEFING_OBSIDIAN_VAULT:-}" ]]; then
+    if [[ -f "$OBSIDIAN_FILE" ]]; then
+      echo -e "  ${DIM}Publishing to Obsidian...${RESET}"
+      echo "[$DATE $(date +%H:%M:%S)] Publishing to Obsidian vault..." >> "$LOG_FILE"
+      if bash "$OBSIDIAN_SCRIPT" --file "$OBSIDIAN_FILE"; then
+        echo "[$DATE $(date +%H:%M:%S)] Obsidian publish complete." >> "$LOG_FILE"
+        echo -e "  ${GREEN}Obsidian${RESET}  published"
+      else
+        echo "[$DATE $(date +%H:%M:%S)] Obsidian publish failed." >> "$LOG_FILE"
+        echo -e "  ${RED}Obsidian${RESET}  failed" >&2
+      fi
+    else
+      echo -e "  ${YELLOW}Obsidian${RESET}  skipped ${DIM}(no markdown file)${RESET}" >&2
+      echo "[$DATE $(date +%H:%M:%S)] Obsidian skipped -- markdown file not found." >> "$LOG_FILE"
+    fi
+  else
+    echo -e "  ${YELLOW}Obsidian${RESET}  skipped ${DIM}(vault not set)${RESET}" >&2
   fi
 fi
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI News Briefing - Project Wiki</title>
-  <meta name="description" content="Comprehensive wiki for AI News Briefing: architecture, E2E flow, operations, multi-channel delivery (Teams + Slack), and maintenance runbook.">
+  <meta name="description" content="Comprehensive wiki for AI News Briefing: architecture, E2E flow, operations, multi-channel delivery (Teams + Slack), Obsidian vault publishing with graph view, and maintenance runbook.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -63,6 +63,7 @@
       <li><a href="#makefile">Makefile</a></li>
       <li><a href="#custom-brief">Custom Brief</a></li>
       <li><a href="#delivery">Delivery</a></li>
+      <li><a href="#obsidian">Obsidian</a></li>
       <li><a href="#tests">Tests</a></li>
       <li><a href="#docs">Docs</a></li>
     </ul>
@@ -75,16 +76,16 @@
 </nav>
 
 <section class="hero">
-  <div class="hero-badge"><span class="dot"></span> Last refreshed: April 6, 2026</div>
+  <div class="hero-badge"><span class="dot"></span> Last refreshed: April 11, 2026</div>
   <h1>AI News Briefing<br><span class="gradient">Comprehensive Project Wiki</span></h1>
   <p class="hero-sub">
     End-to-end reference for the automated daily pipeline and on-demand deep research: scheduler triggers, multi-engine CLI execution (Claude, Codex, Gemini, Copilot),
-    multi-agent research, Notion publishing, Teams and Slack delivery, custom topic briefs, and maintenance workflows.
+    multi-agent research, Notion publishing, Obsidian vault integration with graph visualization, Teams and Slack delivery, custom topic briefs, and maintenance workflows.
   </p>
   <div class="hero-actions">
-    <a href="#architecture" class="btn btn-primary">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
-      View Architecture
+    <a href="#obsidian" class="btn btn-primary">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+      View Obsidian Integration
     </a>
     <a href="README.md" class="btn btn-secondary">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
@@ -97,7 +98,7 @@
   <div class="section-header">
     <div class="section-label">Architecture</div>
     <h2 class="section-title">Current system topology</h2>
-    <p class="section-desc">From scheduler trigger to Notion and optional multi-channel webhook delivery (Teams + Slack).</p>
+    <p class="section-desc">From scheduler trigger to Notion, Obsidian vault, and optional multi-channel webhook delivery (Teams + Slack).</p>
   </div>
 
   <div class="mermaid-wrap">
@@ -117,12 +118,16 @@ flowchart LR
     D --> F["Notion MCP"]
     F --> G["Notion Page"]
     D --> H["card.json"]
+    D --> OBS["obsidian.md"]
     B --> I{"Teams webhook?"}
     I -->|Yes| J["notify-teams"]
     J --> K["Teams Channel"]
     B --> L{"Slack webhook?"}
     L -->|Yes| M["notify-slack"]
     M --> N["Slack Channel"]
+    B --> OC{"Obsidian vault?"}
+    OC -->|Yes| OP["publish-obsidian"]
+    OP --> OV["Obsidian Vault +\nGraph View"]
     </pre>
   </div>
 
@@ -153,6 +158,7 @@ flowchart TD
     D --> CS["logs/covered-stories.txt"]
     D --> H["logs/YYYY-MM-DD.log"]
     D --> I["logs/YYYY-MM-DD-card.json"]
+    D --> OI["logs/YYYY-MM-DD-obsidian.md"]
 
     B1 --> JT{"AI_BRIEFING_TEAMS_WEBHOOK set?"}
     B2 --> JT
@@ -169,6 +175,14 @@ flowchart TD
     LS --> MS{"card JSON exists and conversion succeeds?"}
     MS -->|"Yes"| NS["Convert to Block Kit and POST to Slack webhooks"]
     MS -->|"No"| OS["Slack notify failed"]
+
+    B1 --> JO{"AI_BRIEFING_OBSIDIAN_VAULT set?"}
+    B2 --> JO
+    JO -->|"No"| KO["Skip Obsidian"]
+    JO -->|"Yes"| LO["publish-obsidian script"]
+    LO --> MO{"obsidian.md exists and vault writable?"}
+    MO -->|"Yes"| NO["Copy to vault + create topic stubs"]
+    MO -->|"No"| OO["Obsidian publish skipped"]
       </pre>
     </div>
   </div>
@@ -187,6 +201,8 @@ sequenceDiagram
     participant TW as Teams Webhook(s)
     participant SL as notify-slack
     participant SW as Slack Webhook(s)
+    participant OB as publish-obsidian
+    participant OV as Obsidian Vault
 
     S->>E: Start briefing script
     E->>E: Setup date, logs, env
@@ -223,6 +239,13 @@ sequenceDiagram
       SL->>SW: POST Block Kit payload
       SW-->>SL: 2xx
     end
+
+    opt Obsidian vault configured
+      E->>OB: call publish-obsidian
+      OB->>OB: extract [[wikilinks]]
+      OB->>OV: copy briefing + create topic stubs
+      OV-->>OB: success
+    end
       </pre>
     </div>
   </div>
@@ -249,9 +272,10 @@ sequenceDiagram
         <tr><td>Trigger</td><td>08:00 schedule or manual command</td><td>Script execution starts</td><td><code>com.ainews.briefing.plist</code>, <code>install-task.ps1</code>, <code>Makefile</code></td></tr>
         <tr><td>Bootstrap</td><td>Date + environment</td><td>Prompt text + runtime context</td><td><code>briefing.sh</code>, <code>briefing.ps1</code></td></tr>
         <tr><td>Dedup</td><td><code>logs/covered-stories.txt</code> + latest Notion page</td><td>Exclusion list for this run</td><td>Step 0a (file) + Step 0b (Notion MCP)</td></tr>
-        <tr><td>AI Run</td><td><code>prompt.md</code></td><td>Notion briefing + card.json + covered-stories update</td><td>AI engine (Claude/Codex/Gemini/Copilot), WebSearch, Notion MCP</td></tr>
+        <tr><td>AI Run</td><td><code>prompt.md</code></td><td>Notion briefing + card.json + obsidian.md + covered-stories update</td><td>AI engine (Claude/Codex/Gemini/Copilot), WebSearch, Notion MCP</td></tr>
         <tr><td>Teams Notify</td><td><code>logs/YYYY-MM-DD-card.json</code> + <code>AI_BRIEFING_TEAMS_WEBHOOK</code></td><td>Adaptive Card post(s)</td><td><code>notify-teams.sh</code>, <code>notify-teams.ps1</code></td></tr>
         <tr><td>Slack Notify</td><td><code>logs/YYYY-MM-DD-card.json</code> + <code>AI_BRIEFING_SLACK_WEBHOOK</code></td><td>Block Kit post(s)</td><td><code>notify-slack.sh</code>, <code>notify-slack.ps1</code>, <code>teams-to-slack.py</code></td></tr>
+        <tr><td>Obsidian Publish</td><td><code>logs/YYYY-MM-DD-obsidian.md</code> + <code>AI_BRIEFING_OBSIDIAN_VAULT</code></td><td>Vault briefing page + topic stub pages</td><td><code>publish-obsidian.sh</code>, <code>publish-obsidian.ps1</code></td></tr>
         <tr><td>Multi-URL Routing</td><td>Semicolon-separated webhook URLs</td><td>First URL by default, all URLs with <code>--all</code>/<code>-All</code></td><td>Teams + Slack notify scripts</td></tr>
         <tr><td>Cleanup</td><td>Historic log files</td><td>Old <code>*.log</code> removed</td><td>Entry script cleanup step</td></tr>
       </tbody>
@@ -261,7 +285,7 @@ sequenceDiagram
   <div style="background: rgba(16, 185, 129, 0.10); border: 1px solid rgba(16, 185, 129, 0.35); border-radius: var(--radius); padding: 1.25rem 1.5rem; margin-bottom: 2rem;">
     <h3 style="color: #10b981; font-size: 1rem; margin-bottom: 0.5rem;">Prompt/Runtime Aligned</h3>
     <p style="color: var(--text); font-size: 0.92rem; margin: 0;">
-      <strong>Resolved:</strong> `prompt.md` Step 4 generates `logs/YYYY-MM-DD-card.json` directly. Teams notifier posts this file as-is, and Slack notifier converts the same file to Block Kit before POST.
+      <strong>Resolved:</strong> `prompt.md` Step 4 generates `logs/YYYY-MM-DD-card.json` directly. Step 5 generates `logs/YYYY-MM-DD-obsidian.md` with [[wikilinks]]. Teams notifier posts the card as-is, Slack notifier converts it to Block Kit, and Obsidian publisher copies the markdown to the vault with topic stub pages.
     </p>
   </div>
 
@@ -284,6 +308,15 @@ flowchart TD
     S1 --> S2{teams-to-slack conversion OK?}
     S2 -->|No| S3[Slack notify failed]
     S2 -->|Yes| S4[POST Block Kit to first URL or all URLs]
+
+    A --> OB{obsidian.md exists?}
+    OB -->|No| OB0[Skip Obsidian]
+    OB -->|Yes| OC{Vault env set + writable?}
+    OC -->|No| OC0[Obsidian publish skipped]
+    OC -->|Yes| OC1[publish-obsidian]
+    OC1 --> OC2[Copy to AI-News-Briefings/]
+    OC1 --> OC3["Extract [[wikilinks]]"]
+    OC3 --> OC4[Create Topics/ stub pages]
     </pre>
   </div>
 </section>
@@ -338,6 +371,7 @@ flowchart LR
     S --> OUT["Terminal Output"]
     S -->|"--notion"| N["Notion Page"]
     S -->|"--teams/--slack"| CARD["Card JSON"]
+    S -->|"--obsidian"| OBS["Obsidian Vault +\nGraph View"]
     CARD --> T["Teams"]
     CARD --> SL["Slack"]
     </pre>
@@ -380,8 +414,11 @@ flowchart TD
         SYNTH --> STDOUT["Terminal"]
         SYNTH -->|"--notion"| NOTION["Notion Page"]
         SYNTH -->|"--teams/--slack"| CARD["Card JSON"]
+        SYNTH -->|"--obsidian"| OBSMD["Obsidian Markdown"]
         CARD --> NT["notify-teams"]
         CARD --> NS["notify-slack"]
+        OBSMD --> PO["publish-obsidian"]
+        PO --> OV["Vault +\nTopic Stubs"]
     end
       </pre>
     </div>
@@ -395,19 +432,22 @@ flowchart TD
     </div>
     <div class="code-body">
 <pre><span class="comment"># Full research with all destinations</span>
-<span class="cmd">./custom-brief.sh</span> <span class="flag">--topic</span> <span class="string">"AI in healthcare"</span> <span class="flag">--notion --teams --slack</span>
+<span class="cmd">./custom-brief.sh</span> <span class="flag">--topic</span> <span class="string">"AI in healthcare"</span> <span class="flag">--notion --teams --slack --obsidian</span>
 
 <span class="comment"># Terminal + Notion only</span>
 <span class="cmd">./custom-brief.sh</span> <span class="flag">-t</span> <span class="string">"quantum computing"</span> <span class="flag">-n</span>
+
+<span class="comment"># Terminal + Obsidian vault (graph-enabled)</span>
+<span class="cmd">./custom-brief.sh</span> <span class="flag">-t</span> <span class="string">"AI coding assistants"</span> <span class="flag">--obsidian</span>
 
 <span class="comment"># Interactive mode (prompts for topic and destinations)</span>
 <span class="cmd">./custom-brief.sh</span>
 
 <span class="comment"># PowerShell</span>
-<span class="cmd">.\custom-brief.ps1</span> <span class="flag">-Topic</span> <span class="string">"AI regulation EU"</span> <span class="flag">-Notion -Teams</span>
+<span class="cmd">.\custom-brief.ps1</span> <span class="flag">-Topic</span> <span class="string">"AI regulation EU"</span> <span class="flag">-Notion -Teams -Obsidian</span>
 
 <span class="comment"># Make target</span>
-<span class="cmd">make</span> custom-brief T=<span class="string">"open source LLMs"</span> NOTION=1 TEAMS=1</pre>
+<span class="cmd">make</span> custom-brief T=<span class="string">"open source LLMs"</span> NOTION=1 TEAMS=1 OBSIDIAN=1</pre>
     </div>
   </div>
 
@@ -426,6 +466,7 @@ flowchart TD
       <tr><td>Depth</td><td>Broad scan (search per topic)</td><td>Deep (5 parallel agents + follow-ups)</td></tr>
       <tr><td>Deduplication</td><td>Yes (covered-stories.txt)</td><td>No (standalone)</td></tr>
       <tr><td>Notion title</td><td><code>YYYY-MM-DD - AI Daily Briefing</code></td><td><code>YYYY-MM-DD - Custom Brief: [Topic]</code></td></tr>
+      <tr><td>Obsidian vault file</td><td><code>AI-News-Briefings/YYYY-MM-DD.md</code></td><td><code>AI-News-Briefings/YYYY-MM-DD - [Topic].md</code></td></tr>
       <tr><td>CLI output</td><td>Logged to file only</td><td>Printed to terminal + logged</td></tr>
       <tr><td>Card filename</td><td><code>logs/YYYY-MM-DD-card.json</code></td><td><code>logs/custom-TIMESTAMP-card.json</code></td></tr>
       </tbody>
@@ -526,6 +567,7 @@ flowchart TD
       <tr><td><code>make run-scheduled</code></td><td><span class="cat-badge exec">Execution</span></td><td>Trigger via scheduler service</td></tr>
       <tr><td><code>make custom-brief T="topic"</code></td><td><span class="cat-badge exec">Execution</span></td><td>Deep-research a specific topic</td></tr>
       <tr><td><code>make custom-brief T="..." NOTION=1 TEAMS=1</code></td><td><span class="cat-badge exec">Execution</span></td><td>Research + publish to Notion/Teams</td></tr>
+      <tr><td><code>make custom-brief T="..." OBSIDIAN=1</code></td><td><span class="cat-badge exec">Execution</span></td><td>Research + publish to Obsidian vault</td></tr>
       <tr><td><code>make custom-brief-bg T="..."</code></td><td><span class="cat-badge exec">Execution</span></td><td>Custom brief in background</td></tr>
       <tr><td><code>make tail</code></td><td><span class="cat-badge logs">Logs</span></td><td>Tail today log</td></tr>
       <tr><td><code>make logs</code></td><td><span class="cat-badge logs">Logs</span></td><td>List all logs</td></tr>
@@ -569,6 +611,8 @@ flowchart TD
       <tr><td><code>notify</code></td><td>Native OS status notification</td><td><code>bash scripts/notify.sh</code></td></tr>
       <tr><td><code>notify-teams</code></td><td>Validate and POST Adaptive Card JSON to Teams webhook(s)</td><td><code>bash scripts/notify-teams.sh --all --card-file logs/2026-03-24-card.json</code></td></tr>
       <tr><td><code>notify-slack</code></td><td>Convert Teams card JSON to Block Kit and POST to Slack webhook(s)</td><td><code>bash scripts/notify-slack.sh --all --card-file logs/2026-03-24-card.json</code></td></tr>
+      <tr><td><code>publish-obsidian</code></td><td>Copy Obsidian markdown to vault and create [[wikilink]] topic stubs</td><td><code>bash scripts/publish-obsidian.sh --file logs/2026-04-11-obsidian.md</code></td></tr>
+      <tr><td><code>test-obsidian</code></td><td>Test Obsidian vault connectivity, permissions, and .obsidian config</td><td><code>bash scripts/test-obsidian.sh</code></td></tr>
       <tr><td><code>uninstall</code></td><td>Remove scheduler and optional artifacts</td><td><code>bash scripts/uninstall.sh --all</code></td></tr>
       </tbody>
     </table>
@@ -578,8 +622,8 @@ flowchart TD
 <section class="section" id="delivery">
   <div class="section-header">
     <div class="section-label">Delivery</div>
-    <h2 class="section-title">Teams + Slack webhook paths</h2>
-    <p class="section-desc">Both channels use the same generated <code>logs/YYYY-MM-DD-card.json</code>, with Slack converting it to Block Kit first.</p>
+    <h2 class="section-title">Teams, Slack, and Obsidian publishing paths</h2>
+    <p class="section-desc">Teams and Slack reuse the same <code>logs/YYYY-MM-DD-card.json</code>. Obsidian uses the dedicated <code>logs/YYYY-MM-DD-obsidian.md</code> with <code>[[wikilinks]]</code> for graph visualization.</p>
   </div>
 
   <div class="mermaid-wrap" style="margin-bottom: 2rem;">
@@ -591,6 +635,12 @@ flowchart LR
     C --> E["POST Adaptive Card JSON to Teams webhooks"]
     D --> F["teams-to-slack.py conversion"]
     F --> G["POST Block Kit JSON to Slack webhooks"]
+
+    H["Claude writes logs/YYYY-MM-DD-obsidian.md"] --> I["publish-obsidian.sh / .ps1"]
+    I --> J["Copy to vault/AI-News-Briefings/"]
+    I --> K["Extract [[wikilinks]]"]
+    K --> L["Create Topics/ stub pages"]
+    L --> M["Obsidian Graph View\nvisualizes topic connections"]
     </pre>
   </div>
 
@@ -644,9 +694,165 @@ flowchart LR
     </div>
   </div>
 
+  <div class="code-section" style="max-width: 780px; margin: 0 auto 1.25rem;">
+    <div class="code-header">
+      <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+      <span class="code-title">configure + test Obsidian vault (macOS/Linux)</span>
+      <button class="code-copy">Copy</button>
+    </div>
+    <div class="code-body">
+<pre><span class="comment"># Set vault path (absolute path to your Obsidian vault root)</span>
+<span class="cmd">export</span> AI_BRIEFING_OBSIDIAN_VAULT=<span class="string">"/Users/you/Documents/ObsidianVault"</span>
+
+<span class="comment"># Test vault connectivity</span>
+<span class="cmd">bash</span> scripts/test-obsidian.sh
+
+<span class="comment"># Manual publish (auto-runs after daily briefing when vault is configured)</span>
+<span class="cmd">bash</span> scripts/publish-obsidian.sh <span class="flag">--file</span> logs/2026-04-11-obsidian.md</pre>
+    </div>
+  </div>
+
+  <div class="code-section" style="max-width: 780px; margin: 0 auto 1.25rem;">
+    <div class="code-header">
+      <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+      <span class="code-title">configure + test Obsidian vault (Windows PowerShell)</span>
+      <button class="code-copy">Copy</button>
+    </div>
+    <div class="code-body">
+<pre><span class="comment"># Persist vault path</span>
+[Environment]::SetEnvironmentVariable(<span class="string">"AI_BRIEFING_OBSIDIAN_VAULT"</span>, <span class="string">"C:\Users\you\Documents\ObsidianVault"</span>, <span class="string">"User"</span>)
+
+<span class="comment"># Test vault connectivity</span>
+<span class="cmd">.\scripts\test-obsidian.ps1</span>
+
+<span class="comment"># Manual publish</span>
+<span class="cmd">.\scripts\publish-obsidian.ps1</span> <span class="flag">-File</span> <span class="string">".\logs\2026-04-11-obsidian.md"</span></pre>
+    </div>
+  </div>
+
   <div style="background: rgba(16, 185, 129, 0.10); border: 1px solid rgba(16, 185, 129, 0.35); border-radius: var(--radius); padding: 1rem 1.25rem; max-width: 860px; margin: 0 auto;">
     <p style="color: var(--text); margin: 0; font-size: 0.92rem;">
-      <strong>Legacy note:</strong> `scripts/build-teams-card.py` remains for historical parser flow, but current runtime uses direct card generation in `prompt.md` Step 4. Slack reuses that same card through `scripts/teams-to-slack.py`.
+      <strong>Legacy note:</strong> `scripts/build-teams-card.py` remains for historical parser flow, but current runtime uses direct card generation in `prompt.md` Step 4. Step 5 generates Obsidian-formatted markdown. Slack reuses the card through `scripts/teams-to-slack.py`, and Obsidian publishing writes directly to the local vault.
+    </p>
+  </div>
+</section>
+
+<section class="section" id="obsidian">
+  <div class="section-header">
+    <div class="section-label">Obsidian</div>
+    <h2 class="section-title">Local-first vault publishing with graph visualization</h2>
+    <p class="section-desc">Briefings are written as markdown files with <code>[[wikilinks]]</code> and YAML frontmatter. Obsidian's graph view automatically maps topic connections across all briefings.</p>
+  </div>
+
+  <div class="mermaid-wrap" style="margin-bottom: 2rem;">
+    <pre class="mermaid">
+flowchart TD
+    subgraph "Claude CLI Output"
+        A["logs/YYYY-MM-DD-obsidian.md"]
+    end
+
+    subgraph "publish-obsidian.sh"
+        B["Copy briefing to vault"]
+        C["Extract all [[wikilinks]]"]
+        D{"Topic stub exists?"}
+        D -->|No| E["Create Topics/Name.md\nwith YAML frontmatter"]
+        D -->|Yes| F["Skip (idempotent)"]
+    end
+
+    subgraph "Obsidian Vault"
+        G["AI-News-Briefings/\n2026-04-11.md"]
+        H["Topics/Claude Code.md"]
+        I["Topics/OpenAI.md"]
+        J["Topics/AI Coding IDEs.md"]
+        K["Topics/..."]
+    end
+
+    A --> B --> G
+    A --> C --> D
+    G -.->|"[[Claude Code]]"| H
+    G -.->|"[[OpenAI]]"| I
+    G -.->|"[[AI Coding IDEs]]"| J
+    H -.->|"graph edges"| I
+    I -.->|"graph edges"| J
+    </pre>
+  </div>
+
+  <div style="margin-bottom: 2.5rem;">
+    <h3 style="text-align:center; color:#e4e4ef; font-size:1.15rem; font-weight:700; margin-bottom:1.25rem;">Vault Directory Structure</h3>
+    <div class="file-tree" style="max-width: 680px; margin: 0 auto;">
+      <div><span class="dir">your-obsidian-vault/</span></div>
+      <div>&nbsp;&nbsp;<span class="dir" style="color:#a78bfa;">AI-News-Briefings/</span> <span class="dim"># briefing pages (one per run)</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">2026-04-11.md</span> <span class="dim"># daily briefing with [[wikilinks]]</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">2026-04-11 - AI Coding Assistants.md</span> <span class="dim"># custom brief</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">2026-04-10.md</span></div>
+      <div>&nbsp;&nbsp;<span class="dir" style="color:#a78bfa;">Topics/</span> <span class="dim"># graph hub nodes (auto-created)</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">Claude Code.md</span> <span class="dim"># type: topic, links back to briefings</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">OpenAI.md</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">AI Coding IDEs.md</span></div>
+      <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">Anthropic.md</span></div>
+      <div>&nbsp;&nbsp;<span class="dir">.obsidian/</span> <span class="dim"># Obsidian app config (auto-created by Obsidian)</span></div>
+    </div>
+  </div>
+
+  <div class="mermaid-wrap" style="margin-bottom: 2rem;">
+    <h3 style="text-align:center; color:#e4e4ef; font-size:1.15rem; font-weight:700; margin-bottom:1.25rem;">Graph View Concept</h3>
+    <pre class="mermaid">
+graph LR
+    B1["2026-04-11\nDaily Briefing"] --> CC["Claude Code"]
+    B1 --> OA["OpenAI"]
+    B1 --> ACI["AI Coding IDEs"]
+    B1 --> AG["Agentic AI"]
+    B2["2026-04-10\nDaily Briefing"] --> CC
+    B2 --> OA
+    B2 --> MS["Mistral"]
+    B2 --> HF["Hugging Face"]
+    B3["2026-04-11\nCustom: AI Regulation"] --> POL["AI Policy"]
+    B3 --> OA
+    B3 --> EU["EU AI Act"]
+    CC --> ANT["Anthropic"]
+    ACI --> CUR["Cursor"]
+    ACI --> WS["Windsurf"]
+    style CC fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style OA fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style ACI fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style AG fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style MS fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style HF fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style POL fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style EU fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style ANT fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style CUR fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style WS fill:#7c3aed,stroke:#a78bfa,color:#fff
+    style B1 fill:#1e3a5f,stroke:#3b82f6,color:#fff
+    style B2 fill:#1e3a5f,stroke:#3b82f6,color:#fff
+    style B3 fill:#1e3a5f,stroke:#3b82f6,color:#fff
+    </pre>
+  </div>
+
+  <div class="table-wrap" style="max-width: 860px; margin: 0 auto; margin-bottom: 2rem;">
+    <table>
+      <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Implementation</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr><td>Wikilinks</td><td>Section headings use <code>## [[Topic Name]]</code>, inline mentions wrapped in <code>[[brackets]]</code></td></tr>
+      <tr><td>YAML Frontmatter</td><td>Briefings: <code>type: briefing</code>, <code>date</code>, <code>topics</code> list. Stubs: <code>type: topic</code>, <code>created</code></td></tr>
+      <tr><td>Topic Hub Pages</td><td>Auto-created in <code>Topics/</code> on first reference; idempotent on subsequent runs</td></tr>
+      <tr><td>Graph Edges</td><td>Each <code>[[wikilink]]</code> creates a bidirectional edge in Obsidian's graph view</td></tr>
+      <tr><td>Cross-Briefing Links</td><td>"Related Topics" header links all topics at top of each briefing for maximum connectivity</td></tr>
+      <tr><td>Tags</td><td>YAML <code>tags</code> array enables tag-based filtering in Obsidian search</td></tr>
+      <tr><td>Env Variable</td><td><code>AI_BRIEFING_OBSIDIAN_VAULT</code> — absolute path to vault root directory</td></tr>
+      <tr><td>Local-First</td><td>No API, no cloud sync — files written directly to disk. Obsidian Sync is optional.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div style="background: rgba(139, 92, 246, 0.10); border: 1px solid rgba(139, 92, 246, 0.35); border-radius: var(--radius); padding: 1rem 1.25rem; max-width: 860px; margin: 0 auto;">
+    <p style="color: var(--text); margin: 0; font-size: 0.92rem;">
+      <strong>How the graph grows:</strong> Each daily run adds one briefing page linking to ~9 topic nodes. Each custom brief adds another page with its own topic nodes. Over time, Obsidian's graph view reveals which topics cluster together, which are trending, and how AI news themes evolve. Topic hub pages serve as the gravitational centers of the graph.
     </p>
   </div>
 </section>
@@ -654,26 +860,28 @@ flowchart LR
 <section class="section" id="tests">
   <div class="section-header">
     <div class="section-label">Tests</div>
-    <h2 class="section-title">247 non-blocking tests</h2>
-    <p class="section-desc">Verify syntax, structure, arg handling, template substitution, card JSON, notification error paths, and cross-platform portability. No external services called.</p>
+    <h2 class="section-title">201 non-blocking tests</h2>
+    <p class="section-desc">Verify syntax, structure, arg handling, template substitution, card JSON, notification error paths, Obsidian vault publishing, and cross-platform portability. No external services called.</p>
   </div>
 
   <div class="mermaid-wrap" style="margin-bottom: 2rem;">
     <pre class="mermaid">
 flowchart TD
     subgraph "Bash (macOS / Linux / Git Bash)"
-        R["tests/run-all.sh"] --> T1["test-custom-brief.sh\n37 tests"]
-        R --> T2["test-daily-brief.sh\n56 tests"]
-        R --> T3["test-notifications.sh\n37 tests"]
+        R["tests/run-all.sh"] --> T1["test-custom-brief.sh\n48 tests"]
+        R --> T2["test-daily-brief.sh\n80 tests"]
+        R --> T3["test-notifications.sh\n17 tests"]
         R --> T4["test-portability.sh\n26 tests"]
+        R --> T5["test-obsidian.sh\n30 tests"]
     end
     subgraph "PowerShell (Windows)"
         PS["tests/test-all.ps1\n91 tests"]
     end
-    T1 --> X["Args, templates,\nprompts, skills"]
-    T2 --> Y["Steps, topics,\nchangelogs, scripts"]
+    T1 --> X["Args, templates,\nprompts, skills, Obsidian flag"]
+    T2 --> Y["Steps, topics,\nchangelogs, scripts, Obsidian"]
     T3 --> Z["Card JSON, converter,\nerror handling"]
     T4 --> W["Bash 3.2, awk, date,\nANSI safety"]
+    T5 --> V["Vault structure, topic stubs,\nfrontmatter, idempotency"]
     PS --> X
     PS --> Y
     PS --> Z
@@ -695,6 +903,7 @@ flowchart TD
 <span class="cmd">bash</span> tests/test-daily-brief.sh
 <span class="cmd">bash</span> tests/test-notifications.sh
 <span class="cmd">bash</span> tests/test-portability.sh
+<span class="cmd">bash</span> tests/test-obsidian.sh
 
 <span class="comment"># PowerShell (Windows)</span>
 <span class="cmd">powershell</span> <span class="flag">-ExecutionPolicy Bypass -File</span> tests\test-all.ps1</pre>
@@ -711,10 +920,11 @@ flowchart TD
       </tr>
       </thead>
       <tbody>
-      <tr><td><code>test-custom-brief.sh</code></td><td>37</td><td>Args, template substitution, prompt structure, skill</td></tr>
-      <tr><td><code>test-daily-brief.sh</code></td><td>56</td><td>Prompt steps, 9 topics, 8 changelog URLs, entry scripts, dedup</td></tr>
-      <tr><td><code>test-notifications.sh</code></td><td>37</td><td>Card JSON validity, Adaptive Card structure, converter, errors</td></tr>
+      <tr><td><code>test-custom-brief.sh</code></td><td>48</td><td>Args, template substitution, prompt structure, skill, Obsidian flag</td></tr>
+      <tr><td><code>test-daily-brief.sh</code></td><td>80</td><td>Prompt steps, 9 topics, 8 changelog URLs, entry scripts, dedup, Obsidian integration</td></tr>
+      <tr><td><code>test-notifications.sh</code></td><td>17</td><td>Card JSON validity, Adaptive Card structure, converter, errors</td></tr>
       <tr><td><code>test-portability.sh</code></td><td>26</td><td>Bash 3.2 compat, awk, date, <code>-f</code> not <code>-x</code>, ANSI safety</td></tr>
+      <tr><td><code>test-obsidian.sh</code></td><td>30</td><td>Vault simulation, publish flow, topic stubs, frontmatter, idempotency</td></tr>
       <tr><td><code>test-all.ps1</code></td><td>91</td><td>PowerShell syntax, all prompts, cards, converter, docs</td></tr>
       </tbody>
     </table>
@@ -765,7 +975,7 @@ flowchart TD
   <div class="features">
     <div class="feature-card">
       <h3><a href="README.md">README.md</a></h3>
-      <p>User-facing setup, topic scope, scheduler installation, Makefile commands, and Teams + Slack delivery overview.</p>
+      <p>User-facing setup, topic scope, scheduler installation, Makefile commands, Teams, Slack, and Obsidian delivery overview.</p>
     </div>
     <div class="feature-card">
       <h3><a href="ARCHITECTURE.md">ARCHITECTURE.md</a></h3>
@@ -785,15 +995,15 @@ flowchart TD
     </div>
     <div class="feature-card">
       <h3><a href="prompt.md">prompt.md</a></h3>
-      <p>Agent instructions for search scope, formatting requirements, and Notion write operation.</p>
+      <p>Agent instructions for search scope, formatting requirements, Notion write, and Obsidian markdown with [[wikilinks]].</p>
     </div>
     <div class="feature-card">
       <h3><a href="CUSTOM_BRIEF.md">CUSTOM_BRIEF.md</a></h3>
-      <p>Custom topic deep research: CLI usage, agent architecture, output formats, and comparison with daily briefing.</p>
+      <p>Custom topic deep research: CLI usage, agent architecture, output formats, Obsidian graph support, and comparison with daily briefing.</p>
     </div>
     <div class="feature-card">
       <h3><a href="SETUP.md">SETUP.md</a></h3>
-      <p>Full setup guide: AI CLI engines, Notion MCP, webhook configuration, scheduler install, and verification.</p>
+      <p>Full setup guide: AI CLI engines, Notion MCP, Obsidian vault, webhook configuration, scheduler install, and verification.</p>
     </div>
     <div class="feature-card">
       <h3><a href="NOTIFY_SLACK.md">NOTIFY_SLACK.md</a></h3>
@@ -801,7 +1011,7 @@ flowchart TD
     </div>
     <div class="feature-card">
       <h3><a href="TESTS.md">TESTS.md</a></h3>
-      <p>Test suite documentation: architecture, per-suite coverage tables, run commands, design principles, how to add tests.</p>
+      <p>Test suite documentation: architecture, per-suite coverage tables (including Obsidian suite), run commands, design principles.</p>
     </div>
     <div class="feature-card">
       <h3><a href="LOGS.md">LOGS.md</a></h3>
@@ -825,8 +1035,10 @@ flowchart TD
     <div>&nbsp;&nbsp;<span class="dir">scripts/</span> <span class="dim"># diagnostics, maintenance, notify paths</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">notify-teams.sh / .ps1</span> <span class="dim"># Teams webhook notifier</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">notify-slack.sh / .ps1</span> <span class="dim"># Slack webhook notifier</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file" style="color:#a78bfa;">publish-obsidian.sh / .ps1</span> <span class="dim"># Obsidian vault publisher</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file" style="color:#a78bfa;">test-obsidian.sh / .ps1</span> <span class="dim"># Obsidian vault connectivity test</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">teams-to-slack.py</span> <span class="dim"># Adaptive Card to Block Kit converter</span></div>
-    <div>&nbsp;&nbsp;<span class="dir" style="color:#6366f1;">tests/</span> <span class="dim"># 221 non-blocking tests (bash + PowerShell)</span></div>
+    <div>&nbsp;&nbsp;<span class="dir" style="color:#6366f1;">tests/</span> <span class="dim"># 201 non-blocking tests (bash + PowerShell)</span></div>
     <div>&nbsp;&nbsp;<span class="dir">logs/</span> <span class="dim"># runtime output (gitignored)</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">covered-stories.txt</span> <span class="dim"># dedup headline tracker</span></div>
     <div>&nbsp;&nbsp;<span class="file">README.md</span> <span class="dim"># setup + usage</span></div>
@@ -841,9 +1053,9 @@ flowchart TD
 
 <footer class="footer">
   <div class="footer-inner">
-    <p>AI News Briefing - Powered by Claude Code, Codex, Gemini, and Copilot CLIs with Notion MCP, WebSearch, multi-agent research, and multi-channel delivery.</p>
+    <p>AI News Briefing - Powered by Claude Code, Codex, Gemini, and Copilot CLIs with Notion MCP, WebSearch, multi-agent research, Obsidian graph view, and multi-channel delivery.</p>
     <p style="margin-top: 0.5rem; color: #8888a0; font-size: 0.85rem;">
-      Automated daily briefings + on-demand deep topic research with Notion, Teams, and Slack publishing.
+      Automated daily briefings + on-demand deep topic research with Notion, Obsidian, Teams, and Slack publishing.
     </p>
     <div class="footer-links">
       <a href="README.md">README</a>

--- a/prompt-custom-brief.md
+++ b/prompt-custom-brief.md
@@ -4,6 +4,7 @@ You are a deep research agent specializing in AI and technology news intelligenc
 
 - **TOPIC:** {{TOPIC}}
 - **PUBLISH_NOTION:** {{PUBLISH_NOTION}}
+- **PUBLISH_OBSIDIAN:** {{PUBLISH_OBSIDIAN}}
 - **PUBLISH_TEAMS_SLACK:** {{PUBLISH_TEAMS_SLACK}}
 - **TIMESTAMP:** {{TIMESTAMP}}
 
@@ -176,6 +177,78 @@ If `{{PUBLISH_NOTION}}` is `false`, skip this step entirely.
 
 ---
 
+## Phase 5b: Generate Obsidian Markdown (only if PUBLISH_OBSIDIAN = true)
+
+If `{{PUBLISH_OBSIDIAN}}` is `true`:
+
+Write an Obsidian-formatted version of the briefing to `logs/custom-{{TIMESTAMP}}-obsidian.md`. The calling script handles copying it to the Obsidian vault and creating topic stub pages for the graph.
+
+The key difference from Notion: use `[[wikilinks]]` to topic pages so Obsidian's graph view shows connections.
+
+**Template:**
+
+```markdown
+---
+date: {{DATE}}
+type: custom-brief
+topic: {{TOPIC}}
+sections:
+  - Section Title 1
+  - Section Title 2
+tags:
+  - ai-news
+  - custom-brief
+---
+
+# Custom Brief: {{TOPIC}}
+
+*Research date: {{DATE}}*
+*Sources consulted: N*
+
+> Related topics: [[Topic 1]] · [[Topic 2]] · [[Topic 3]]
+
+---
+
+## TL;DR
+
+- Bullet points (same as Phase 3)
+
+---
+
+## [[Topic 1 Name]]
+
+**Finding** — Summary. Source: [Pub](URL) (Date)
+
+---
+
+(continue for each thematic section, wrapping key topic names in [[wikilinks]])
+
+---
+
+## Key Trends & Outlook
+
+| Trend | Signal | Implication |
+|-------|--------|-------------|
+| ... | ... | ... |
+
+---
+
+## Sources
+
+1. [Title](URL) — Publication, Date
+```
+
+**Rules:**
+- Wrap each thematic section's primary topic in `[[double brackets]]` in headings and "Related topics" line.
+- For each finding, wrap relevant company/product/technology names in `[[wikilinks]]` where natural (e.g., "[[OpenAI]] released..." or "the [[Anthropic]] team announced...").
+- Use YAML frontmatter with date, type, topic, sections list, and tags.
+- Use standard Markdown (not Notion-flavored).
+- Do NOT write to the vault yourself. Only write to `logs/`. The calling script handles publishing.
+
+If `{{PUBLISH_OBSIDIAN}}` is `false`, skip this step entirely.
+
+---
+
 ## Phase 6: Generate Teams/Slack Card JSON (only if PUBLISH_TEAMS_SLACK = true)
 
 If `{{PUBLISH_TEAMS_SLACK}}` is `true`:
@@ -294,4 +367,5 @@ If `{{PUBLISH_TEAMS_SLACK}}` is `false`, skip this step entirely.
 - [ ] Numbered Sources list at the end includes every URL cited
 - [ ] Full briefing was printed to stdout
 - [ ] Notion page created (if PUBLISH_NOTION = true)
+- [ ] Obsidian markdown written with [[wikilinks]] (if PUBLISH_OBSIDIAN = true)
 - [ ] Card JSON written (if PUBLISH_TEAMS_SLACK = true) and is valid JSON under 24KB

--- a/prompt.md
+++ b/prompt.md
@@ -233,7 +233,80 @@ Use the `Write` tool to save the file. Use the template below, replacing the pla
 - Use short display names (publication name only, not full article titles).
 - If there are too many sources to fit, prioritize primary/original sources over aggregators.
 
-## Step 5: Update Covered Stories List
+## Step 5: Generate Obsidian Markdown
+
+Write an Obsidian-formatted version of the briefing to `logs/YYYY-MM-DD-obsidian.md`. This file will be published to the user's Obsidian vault by the calling script. The key difference from Notion: use `[[wikilinks]]` to topic pages so Obsidian's graph view shows topic connections across briefings.
+
+Use the `Write` tool to save the file. The calling script (`publish-obsidian.sh` / `publish-obsidian.ps1`) handles copying it to the vault.
+
+**Template:**
+
+```markdown
+---
+date: YYYY-MM-DD
+type: daily-briefing
+topics:
+  - Claude Code / Anthropic
+  - OpenAI / Codex / ChatGPT
+  - AI Coding IDEs
+  - Agentic AI Ecosystem
+  - AI Industry
+  - Open Source AI
+  - AI Startups & Funding
+  - AI Policy & Regulation
+  - Dev Tools & Frameworks
+tags:
+  - ai-news
+  - daily-briefing
+---
+
+# AI Daily Briefing — YYYY-MM-DD
+
+> Related topics: [[Claude Code]] · [[Anthropic]] · [[OpenAI]] · [[AI Coding IDEs]] · [[Agentic AI]] · [[AI Industry]] · [[Open Source AI]] · [[AI Startups]] · [[AI Policy]] · [[Dev Tools]]
+
+---
+
+## TL;DR
+
+- Bullet points from the briefing (same content as Notion)
+
+---
+
+## [[Claude Code]] / [[Anthropic]]
+
+- Story bullets with **bold** emphasis and source links
+
+---
+
+## [[OpenAI]] / Codex / ChatGPT
+
+- Story bullets...
+
+(continue for each section, wrapping topic names in [[wikilinks]])
+
+---
+
+## Key Takeaways
+
+| Theme | Signal |
+|-------|--------|
+| theme | signal |
+
+---
+
+## Sources
+
+1. [Title](URL) — Publication, Date
+```
+
+**Obsidian Formatting Rules:**
+- Wrap each major topic name in `[[double brackets]]` in section headings and in the "Related topics" line. This creates links that Obsidian's graph view uses to show connections.
+- Use standard Markdown (not Notion-flavored). Use `|` tables, `---` dividers, `> ` blockquotes.
+- Include YAML frontmatter with date, type, topics list, and tags.
+- Only include sections that have news content (skip "No major updates today" sections).
+- The content should match the Notion briefing but reformatted with wikilinks.
+
+## Step 6: Update Covered Stories List
 
 After generating the briefing and card, append today's story headlines to `logs/covered-stories.txt`. This file is used for deduplication in future runs.
 

--- a/scripts/publish-obsidian.ps1
+++ b/scripts/publish-obsidian.ps1
@@ -1,0 +1,99 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# publish-obsidian.ps1 — Publish a briefing markdown file to an Obsidian vault.
+# Creates topic stub pages for graph visualization if they don't already exist.
+#
+# Usage:
+#   .\scripts\publish-obsidian.ps1 -File logs\2026-04-11-obsidian.md
+#
+# Requires: AI_BRIEFING_OBSIDIAN_VAULT environment variable set to the vault path.
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$File
+)
+
+# -- Validate inputs ---------------------------------------
+if (-not (Test-Path $File)) {
+    Write-Host "  ERROR  Source file not found: $File" -ForegroundColor Red
+    exit 1
+}
+
+$Vault = $env:AI_BRIEFING_OBSIDIAN_VAULT
+if (-not $Vault) {
+    # Check user-level env var
+    $Vault = [Environment]::GetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "User")
+}
+
+if (-not $Vault) {
+    Write-Host "  ERROR  AI_BRIEFING_OBSIDIAN_VAULT is not set" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $Vault -PathType Container)) {
+    Write-Host "  ERROR  Vault directory not found: $Vault" -ForegroundColor Red
+    exit 1
+}
+
+# -- Ensure vault subdirectories exist ---------------------
+$BriefingsDir = Join-Path $Vault "AI-News-Briefings"
+$TopicsDir = Join-Path $Vault "Topics"
+New-Item -ItemType Directory -Path $BriefingsDir -Force | Out-Null
+New-Item -ItemType Directory -Path $TopicsDir -Force | Out-Null
+
+# -- Copy briefing to vault --------------------------------
+$FileName = (Split-Path $File -Leaf) -replace '-obsidian\.md$', '.md'
+$DestFile = Join-Path $BriefingsDir $FileName
+
+Copy-Item -Path $File -Destination $DestFile -Force
+Write-Host "  Published  " -ForegroundColor Green -NoNewline
+Write-Host "$DestFile"
+
+# -- Create topic stub pages for graph nodes ---------------
+$content = Get-Content -Path $File -Raw
+$topics = [regex]::Matches($content, '\[\[([^\]]+)\]\]') | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+
+$created = 0
+$existing = 0
+
+foreach ($topic in $topics) {
+    if (-not $topic) { continue }
+    $topicFile = Join-Path $TopicsDir "$topic.md"
+
+    if (-not (Test-Path $topicFile)) {
+        $date = Get-Date -Format "yyyy-MM-dd"
+        $stub = @"
+---
+type: topic
+created: $date
+---
+
+# $topic
+
+This is a topic hub for **$topic** in the AI News Briefing system.
+
+Briefings mentioning this topic are automatically linked via Obsidian's backlinks panel and graph view.
+
+## See Also
+
+Check the **Backlinks** panel (or graph view) to see all briefings referencing this topic.
+"@
+        $stub | Out-File -FilePath $topicFile -Encoding utf8
+        $created++
+    } else {
+        $existing++
+    }
+}
+
+if ($created -gt 0) {
+    Write-Host "  Topics     " -ForegroundColor Green -NoNewline
+    Write-Host "$created new topic page(s) created, $existing already existed"
+} else {
+    Write-Host "  Topics     " -ForegroundColor DarkGray -NoNewline
+    Write-Host "all $existing topic pages already exist"
+}
+
+Write-Host "  Graph      " -ForegroundColor DarkGray -NoNewline
+Write-Host "open Obsidian and check the graph view to see topic connections"

--- a/scripts/publish-obsidian.sh
+++ b/scripts/publish-obsidian.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+# publish-obsidian.sh — Publish a briefing markdown file to an Obsidian vault.
+# Creates topic stub pages for graph visualization if they don't already exist.
+#
+# Usage:
+#   ./scripts/publish-obsidian.sh --file logs/2026-04-11-obsidian.md
+#   ./scripts/publish-obsidian.sh --file logs/custom-2026-04-11-090000-obsidian.md
+#
+# Requires: AI_BRIEFING_OBSIDIAN_VAULT environment variable set to the vault path.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# -- Colors (auto-disable if not a terminal) ---------------
+if [[ -t 1 ]]; then
+  BOLD='\033[1m' DIM='\033[2m' RESET='\033[0m'
+  GREEN='\033[32m' RED='\033[31m' YELLOW='\033[33m' CYAN='\033[36m'
+else
+  BOLD='' DIM='' RESET='' GREEN='' RED='' YELLOW='' CYAN=''
+fi
+
+# -- Defaults ----------------------------------------------
+SOURCE_FILE=""
+
+# -- Parse arguments ---------------------------------------
+print_usage() {
+  cat <<'EOF'
+Usage: publish-obsidian.sh [OPTIONS]
+
+Publish a briefing markdown file to an Obsidian vault with graph-ready wikilinks.
+
+Options:
+  --file, -f FILE    Source markdown file to publish (required)
+  --help, -h         Show this help
+
+Environment:
+  AI_BRIEFING_OBSIDIAN_VAULT   Path to Obsidian vault directory (required)
+
+Examples:
+  ./scripts/publish-obsidian.sh --file logs/2026-04-11-obsidian.md
+  AI_BRIEFING_OBSIDIAN_VAULT=~/Documents/MyVault ./scripts/publish-obsidian.sh -f logs/custom-*-obsidian.md
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file|-f)
+      if [[ $# -lt 2 ]]; then echo "ERROR: --file requires a value" >&2; exit 1; fi
+      SOURCE_FILE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+# -- Validate inputs ---------------------------------------
+if [[ -z "$SOURCE_FILE" ]]; then
+  echo -e "  ${RED}ERROR${RESET}  --file is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SOURCE_FILE" ]]; then
+  echo -e "  ${RED}ERROR${RESET}  Source file not found: $SOURCE_FILE" >&2
+  exit 1
+fi
+
+VAULT="${AI_BRIEFING_OBSIDIAN_VAULT:-}"
+if [[ -z "$VAULT" ]]; then
+  echo -e "  ${RED}ERROR${RESET}  AI_BRIEFING_OBSIDIAN_VAULT is not set" >&2
+  exit 1
+fi
+
+if [[ ! -d "$VAULT" ]]; then
+  echo -e "  ${RED}ERROR${RESET}  Vault directory not found: $VAULT" >&2
+  exit 1
+fi
+
+# -- Ensure vault subdirectories exist ---------------------
+BRIEFINGS_DIR="$VAULT/AI-News-Briefings"
+TOPICS_DIR="$VAULT/Topics"
+mkdir -p "$BRIEFINGS_DIR" "$TOPICS_DIR"
+
+# -- Copy briefing to vault --------------------------------
+FILENAME="$(basename "$SOURCE_FILE" | sed 's/-obsidian\.md$/.md/')"
+DEST_FILE="$BRIEFINGS_DIR/$FILENAME"
+
+cp "$SOURCE_FILE" "$DEST_FILE"
+echo -e "  ${GREEN}Published${RESET}  $DEST_FILE"
+
+# -- Create topic stub pages for graph nodes ---------------
+# Extract [[wikilinks]] from the file and create stub pages for any missing topics
+TOPICS=$(grep -oE '\[\[[^]]+\]\]' "$SOURCE_FILE" | sed 's/\[\[//g; s/\]\]//g' | sort -u)
+
+CREATED=0
+EXISTING=0
+while IFS= read -r topic; do
+  [[ -z "$topic" ]] && continue
+  TOPIC_FILE="$TOPICS_DIR/$topic.md"
+  if [[ ! -f "$TOPIC_FILE" ]]; then
+    cat > "$TOPIC_FILE" <<TOPICEOF
+---
+type: topic
+created: $(date +%Y-%m-%d)
+---
+
+# $topic
+
+This is a topic hub for **$topic** in the AI News Briefing system.
+
+Briefings mentioning this topic are automatically linked via Obsidian's backlinks panel and graph view.
+
+## See Also
+
+Check the **Backlinks** panel (or graph view) to see all briefings referencing this topic.
+TOPICEOF
+    CREATED=$((CREATED + 1))
+  else
+    EXISTING=$((EXISTING + 1))
+  fi
+done <<< "$TOPICS"
+
+if [[ "$CREATED" -gt 0 ]]; then
+  echo -e "  ${GREEN}Topics${RESET}    $CREATED new topic page(s) created, $EXISTING already existed"
+else
+  echo -e "  ${DIM}Topics${RESET}    all $EXISTING topic pages already exist"
+fi
+
+echo -e "  ${DIM}Graph${RESET}     open Obsidian and check the graph view to see topic connections"

--- a/scripts/test-obsidian.ps1
+++ b/scripts/test-obsidian.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# test-obsidian.ps1 — Test Obsidian vault connectivity on Windows.
+# Verifies that the vault directory exists and is writable.
+# Usage: .\scripts\test-obsidian.ps1
+
+Write-Host ""
+Write-Host "  AI News Briefing - Obsidian Vault Connectivity Test" -ForegroundColor White
+Write-Host "  ===================================================="
+Write-Host ""
+
+$Vault = $env:AI_BRIEFING_OBSIDIAN_VAULT
+if (-not $Vault) {
+    $Vault = [Environment]::GetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "User")
+}
+
+if (-not $Vault) {
+    Write-Host "  FAIL  AI_BRIEFING_OBSIDIAN_VAULT is not set." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "  Set it to your Obsidian vault path:"
+    Write-Host '    [Environment]::SetEnvironmentVariable("AI_BRIEFING_OBSIDIAN_VAULT", "C:\path\to\vault", "User")'
+    Write-Host ""
+    exit 1
+}
+
+Write-Host "  Vault path: $Vault"
+
+if (-not (Test-Path $Vault -PathType Container)) {
+    Write-Host "  FAIL  Directory does not exist: $Vault" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  Directory:  exists" -ForegroundColor Green
+
+# Check if writable
+try {
+    $testFile = Join-Path $Vault ".ai-briefing-write-test"
+    "" | Out-File -FilePath $testFile -Encoding utf8
+    Remove-Item $testFile -Force
+    Write-Host "  Writable:   yes" -ForegroundColor Green
+} catch {
+    Write-Host "  FAIL  Directory is not writable: $Vault" -ForegroundColor Red
+    exit 1
+}
+
+# Check if it looks like an Obsidian vault
+$obsidianDir = Join-Path $Vault ".obsidian"
+if (Test-Path $obsidianDir -PathType Container) {
+    Write-Host "  Obsidian:   .obsidian config found (confirmed vault)" -ForegroundColor Green
+} else {
+    Write-Host "  Obsidian:   no .obsidian config (directory will work but may not be initialized as a vault)" -ForegroundColor Yellow
+}
+
+# Check subdirectories
+$briefingsDir = Join-Path $Vault "AI-News-Briefings"
+$topicsDir = Join-Path $Vault "Topics"
+
+if (Test-Path $briefingsDir -PathType Container) {
+    $count = (Get-ChildItem -Path $briefingsDir -Filter "*.md" -File).Count
+    Write-Host "  Briefings:  $count file(s) in AI-News-Briefings/"
+} else {
+    Write-Host "  Briefings:  AI-News-Briefings/ will be created on first publish" -ForegroundColor DarkGray
+}
+
+if (Test-Path $topicsDir -PathType Container) {
+    $count = (Get-ChildItem -Path $topicsDir -Filter "*.md" -File).Count
+    Write-Host "  Topics:     $count topic page(s) in Topics/"
+} else {
+    Write-Host "  Topics:     Topics/ will be created on first publish" -ForegroundColor DarkGray
+}
+
+Write-Host ""
+Write-Host "  Test complete. Obsidian vault is ready." -ForegroundColor Green
+Write-Host ""

--- a/scripts/test-obsidian.sh
+++ b/scripts/test-obsidian.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# test-obsidian.sh — Test Obsidian vault connectivity.
+# Verifies that the vault directory exists and is writable.
+# Usage: ./scripts/test-obsidian.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo ""
+echo "  AI News Briefing — Obsidian Vault Connectivity Test"
+echo "  ===================================================="
+echo ""
+
+VAULT="${AI_BRIEFING_OBSIDIAN_VAULT:-}"
+
+if [[ -z "$VAULT" ]]; then
+  echo "  FAIL  AI_BRIEFING_OBSIDIAN_VAULT is not set."
+  echo ""
+  echo "  Set it to your Obsidian vault path:"
+  echo "    export AI_BRIEFING_OBSIDIAN_VAULT=\"/path/to/your/vault\""
+  echo ""
+  exit 1
+fi
+
+echo "  Vault path: $VAULT"
+
+if [[ ! -d "$VAULT" ]]; then
+  echo "  FAIL  Directory does not exist: $VAULT"
+  exit 1
+fi
+echo "  Directory:  exists"
+
+if [[ ! -w "$VAULT" ]]; then
+  echo "  FAIL  Directory is not writable: $VAULT"
+  exit 1
+fi
+echo "  Writable:   yes"
+
+# Check if it looks like an Obsidian vault
+if [[ -d "$VAULT/.obsidian" ]]; then
+  echo "  Obsidian:   .obsidian config found (confirmed vault)"
+else
+  echo "  Obsidian:   no .obsidian config (directory will work but may not be initialized as a vault)"
+fi
+
+# Check subdirectories
+BRIEFINGS_DIR="$VAULT/AI-News-Briefings"
+TOPICS_DIR="$VAULT/Topics"
+
+if [[ -d "$BRIEFINGS_DIR" ]]; then
+  COUNT=$(find "$BRIEFINGS_DIR" -name "*.md" -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
+  echo "  Briefings:  $COUNT file(s) in AI-News-Briefings/"
+else
+  echo "  Briefings:  AI-News-Briefings/ will be created on first publish"
+fi
+
+if [[ -d "$TOPICS_DIR" ]]; then
+  COUNT=$(find "$TOPICS_DIR" -name "*.md" -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
+  echo "  Topics:     $COUNT topic page(s) in Topics/"
+else
+  echo "  Topics:     Topics/ will be created on first publish"
+fi
+
+echo ""
+echo "  Test complete. Obsidian vault is ready."
+echo ""

--- a/tests/test-all.ps1
+++ b/tests/test-all.ps1
@@ -136,6 +136,7 @@ $result = $cbPrompt.
     Replace('{{DATE}}', $testDate).
     Replace('{{TIMESTAMP}}', $testTs).
     Replace('{{PUBLISH_NOTION}}', 'true').
+    Replace('{{PUBLISH_OBSIDIAN}}', 'false').
     Replace('{{PUBLISH_TEAMS_SLACK}}', 'false')
 
 Assert-Contains $result 'AI in R&D' "substitution: handles & in topic"
@@ -171,7 +172,7 @@ Write-Host ""
 Write-Host "=== Card JSON validation ===" -ForegroundColor Cyan
 
 $cardDir = Join-Path $ScriptDir "logs"
-$cards = Get-ChildItem -Path $cardDir -Filter "*-card.json" -ErrorAction SilentlyContinue
+$cards = @(Get-ChildItem -Path $cardDir -Filter "*-card.json" -ErrorAction SilentlyContinue)
 
 if ($cards.Count -gt 0) {
     Test-Pass "found $($cards.Count) card JSON files"

--- a/tests/test-custom-brief.sh
+++ b/tests/test-custom-brief.sh
@@ -53,6 +53,7 @@ assert_contains "$help_output" "--topic" "help: mentions --topic"
 assert_contains "$help_output" "--notion" "help: mentions --notion"
 assert_contains "$help_output" "--teams" "help: mentions --teams"
 assert_contains "$help_output" "--slack" "help: mentions --slack"
+assert_contains "$help_output" "--obsidian" "help: mentions --obsidian"
 
 # -- Short help flag ---------------------------------------
 help_short=$(bash "$CUSTOM_BRIEF" -h 2>&1) || true
@@ -78,6 +79,7 @@ assert_contains "$tmpl" '{{DATE}}' "template: has {{DATE}} placeholder"
 assert_contains "$tmpl" '{{TIMESTAMP}}' "template: has {{TIMESTAMP}} placeholder"
 assert_contains "$tmpl" '{{PUBLISH_NOTION}}' "template: has {{PUBLISH_NOTION}} placeholder"
 assert_contains "$tmpl" '{{PUBLISH_TEAMS_SLACK}}' "template: has {{PUBLISH_TEAMS_SLACK}} placeholder"
+assert_contains "$tmpl" '{{PUBLISH_OBSIDIAN}}' "template: has {{PUBLISH_OBSIDIAN}} placeholder"
 assert_contains "$tmpl" "Phase 1" "template: has Phase 1 (Broad Discovery)"
 assert_contains "$tmpl" "Phase 2" "template: has Phase 2 (Deep Dive)"
 assert_contains "$tmpl" "Phase 3" "template: has Phase 3 (Compile)"
@@ -96,19 +98,22 @@ result=$(awk \
   -v ts="2026-04-01-090000" \
   -v notion="true" \
   -v tslack="false" \
+  -v obsidian="true" \
   '{
     gsub(/\{\{TOPIC\}\}/, topic)
     gsub(/\{\{DATE\}\}/, date)
     gsub(/\{\{TIMESTAMP\}\}/, ts)
     gsub(/\{\{PUBLISH_NOTION\}\}/, notion)
     gsub(/\{\{PUBLISH_TEAMS_SLACK\}\}/, tslack)
+    gsub(/\{\{PUBLISH_OBSIDIAN\}\}/, obsidian)
     print
-  }' <<< "Topic: {{TOPIC}} Date: {{DATE}} Notion: {{PUBLISH_NOTION}}")
+  }' <<< "Topic: {{TOPIC}} Date: {{DATE}} Notion: {{PUBLISH_NOTION}} Obsidian: {{PUBLISH_OBSIDIAN}}")
 
 assert_contains "$result" "AI regulation in the EU" "awk substitution: topic injected"
 assert_contains "$result" "(2026)" "awk substitution: parens preserved in topic"
 assert_contains "$result" "2026-04-01" "awk substitution: replaces {{DATE}}"
 assert_contains "$result" "Notion: true" "awk substitution: replaces {{PUBLISH_NOTION}}"
+assert_contains "$result" "Obsidian: true" "awk substitution: replaces {{PUBLISH_OBSIDIAN}}"
 
 # Test no leftover placeholders
 leftover=$(awk \
@@ -117,12 +122,14 @@ leftover=$(awk \
   -v ts="2026-04-01-090000" \
   -v notion="false" \
   -v tslack="true" \
+  -v obsidian="false" \
   '{
     gsub(/\{\{TOPIC\}\}/, topic)
     gsub(/\{\{DATE\}\}/, date)
     gsub(/\{\{TIMESTAMP\}\}/, ts)
     gsub(/\{\{PUBLISH_NOTION\}\}/, notion)
     gsub(/\{\{PUBLISH_TEAMS_SLACK\}\}/, tslack)
+    gsub(/\{\{PUBLISH_OBSIDIAN\}\}/, obsidian)
     print
   }' "$PROMPT_TEMPLATE" | grep -c '{{' || true)
 assert_eq "$leftover" "0" "awk substitution: no leftover {{}} placeholders"
@@ -138,6 +145,25 @@ assert_contains "$skill" "Agent 1" "skill: defines parallel agents"
 assert_contains "$skill" "mcp__notion__notion-create-pages" "skill: uses Notion MCP"
 assert_contains "$skill" "856794cc-d871-4a95-be2d-2a1600920a19" "skill: has correct data_source_id"
 assert_contains "$skill" "Quality Checklist" "skill: has quality checklist"
+
+# -- Obsidian integration (custom-brief.sh) ----------------
+echo ""
+section "Obsidian integration (custom-brief.sh)"
+cb=$(cat "$CUSTOM_BRIEF")
+assert_contains "$cb" "PUBLISH_OBSIDIAN" "custom-brief.sh: has PUBLISH_OBSIDIAN variable"
+assert_contains "$cb" "obsidian" "custom-brief.sh: has obsidian flag handling"
+assert_contains "$cb" "publish-obsidian" "custom-brief.sh: calls publish-obsidian script"
+
+# -- Obsidian integration (prompt template) ----------------
+section "Obsidian integration (prompt-custom-brief.md)"
+assert_contains "$tmpl" "Obsidian" "template: mentions Obsidian"
+assert_contains "$tmpl" "PUBLISH_OBSIDIAN" "template: has PUBLISH_OBSIDIAN parameter"
+assert_contains "$tmpl" "obsidian.md" "template: references obsidian.md output"
+assert_contains "$tmpl" "[[" "template: uses [[wikilinks]] syntax"
+
+# -- Obsidian integration (skill) --------------------------
+section "Obsidian integration (commands/custom-brief.md)"
+assert_contains "$skill" "Obsidian" "skill: mentions Obsidian"
 
 # -- Summary -----------------------------------------------
 echo ""

--- a/tests/test-daily-brief.sh
+++ b/tests/test-daily-brief.sh
@@ -47,7 +47,8 @@ assert_contains "$prompt" "Step 1" "prompt: has Step 1 (search)"
 assert_contains "$prompt" "Step 2" "prompt: has Step 2 (compile)"
 assert_contains "$prompt" "Step 3" "prompt: has Step 3 (write to Notion)"
 assert_contains "$prompt" "Step 4" "prompt: has Step 4 (card JSON)"
-assert_contains "$prompt" "Step 5" "prompt: has Step 5 (covered stories update)"
+assert_contains "$prompt" "Step 5" "prompt: has Step 5 (Obsidian markdown)"
+assert_contains "$prompt" "Step 6" "prompt: has Step 6 (covered stories update)"
 assert_contains "$prompt" "856794cc-d871-4a95-be2d-2a1600920a19" "prompt: has correct data_source_id"
 assert_contains "$prompt" "covered-stories.txt" "prompt: references dedup file"
 assert_contains "$prompt" "mcp__notion__notion-search" "prompt: uses Notion search MCP"
@@ -117,6 +118,61 @@ if [ -f "$COVERED" ]; then
 else
   pass "covered-stories.txt not yet created (OK for fresh install)"
 fi
+
+# -- Obsidian integration (prompt.md) ----------------------
+section "Obsidian integration (prompt.md)"
+assert_contains "$prompt" "Obsidian" "prompt: mentions Obsidian"
+assert_contains "$prompt" "obsidian.md" "prompt: references obsidian.md output file"
+assert_contains "$prompt" "[[" "prompt: uses [[wikilinks]] syntax"
+assert_contains "$prompt" "frontmatter" "prompt: requires YAML frontmatter"
+
+# -- Obsidian integration (briefing.sh) --------------------
+section "Obsidian integration (briefing.sh)"
+assert_contains "$entry" "publish-obsidian" "briefing.sh: calls Obsidian publisher"
+assert_contains "$entry" "OBSIDIAN_VAULT" "briefing.sh: checks vault env var"
+assert_contains "$entry" "obsidian.md" "briefing.sh: references obsidian.md file"
+
+# -- Obsidian integration (briefing.ps1) -------------------
+section "Obsidian integration (briefing.ps1)"
+assert_contains "$ps_entry" "publish-obsidian" "briefing.ps1: calls Obsidian publisher"
+assert_contains "$ps_entry" "OBSIDIAN_VAULT" "briefing.ps1: checks vault env var"
+assert_contains "$ps_entry" "obsidian.md" "briefing.ps1: references obsidian.md file"
+
+# -- Obsidian publish script existence ---------------------
+section "Obsidian publish scripts"
+[ -f "$SCRIPT_DIR/scripts/publish-obsidian.sh" ] && pass "publish-obsidian.sh exists" || fail "publish-obsidian.sh exists"
+[ -x "$SCRIPT_DIR/scripts/publish-obsidian.sh" ] && pass "publish-obsidian.sh is executable" || fail "publish-obsidian.sh is executable"
+[ -f "$SCRIPT_DIR/scripts/publish-obsidian.ps1" ] && pass "publish-obsidian.ps1 exists" || fail "publish-obsidian.ps1 exists"
+[ -f "$SCRIPT_DIR/scripts/test-obsidian.sh" ] && pass "test-obsidian.sh exists" || fail "test-obsidian.sh exists"
+[ -x "$SCRIPT_DIR/scripts/test-obsidian.sh" ] && pass "test-obsidian.sh is executable" || fail "test-obsidian.sh is executable"
+[ -f "$SCRIPT_DIR/scripts/test-obsidian.ps1" ] && pass "test-obsidian.ps1 exists" || fail "test-obsidian.ps1 exists"
+
+# -- Obsidian publish script syntax ------------------------
+section "Obsidian script syntax"
+if bash -n "$SCRIPT_DIR/scripts/publish-obsidian.sh" 2>/dev/null; then
+  pass "publish-obsidian.sh valid bash syntax"
+else
+  fail "publish-obsidian.sh valid bash syntax"
+fi
+if bash -n "$SCRIPT_DIR/scripts/test-obsidian.sh" 2>/dev/null; then
+  pass "test-obsidian.sh valid bash syntax"
+else
+  fail "test-obsidian.sh valid bash syntax"
+fi
+
+# -- Obsidian publish script structure ---------------------
+section "Obsidian publish script structure"
+pub_obs=$(cat "$SCRIPT_DIR/scripts/publish-obsidian.sh")
+assert_contains "$pub_obs" "set -euo pipefail" "publish-obsidian.sh: uses strict mode"
+assert_contains "$pub_obs" "AI-News-Briefings" "publish-obsidian.sh: uses briefings subdirectory"
+assert_contains "$pub_obs" "Topics" "publish-obsidian.sh: uses topics subdirectory"
+assert_contains "$pub_obs" "[[" "publish-obsidian.sh: extracts wikilinks"
+assert_contains "$pub_obs" "type: topic" "publish-obsidian.sh: creates YAML topic type for stubs"
+assert_contains "$pub_obs" "OBSIDIAN_VAULT" "publish-obsidian.sh: reads vault env var"
+
+# -- Obsidian skill references -----------------------------
+section "Obsidian in skill files"
+assert_contains "$skill" "Obsidian" "daily skill: mentions Obsidian"
 
 # -- Summary -----------------------------------------------
 echo ""

--- a/tests/test-obsidian.sh
+++ b/tests/test-obsidian.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Tests for Obsidian publishing pipeline — non-blocking (no vault writes)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PUBLISH_SCRIPT="$SCRIPT_DIR/scripts/publish-obsidian.sh"
+TEST_SCRIPT="$SCRIPT_DIR/scripts/test-obsidian.sh"
+
+PASS=0
+FAIL=0
+
+# -- Colors (auto-disable if piped) --
+if [[ -t 1 ]]; then
+  B='\033[1m' D='\033[2m' R='\033[0m'
+  GRN='\033[32m' RED='\033[31m' CYN='\033[36m' YLW='\033[33m' MAG='\033[35m'
+else
+  B='' D='' R='' GRN='' RED='' CYN='' YLW='' MAG=''
+fi
+
+pass() { PASS=$((PASS + 1)); echo -e "  ${GRN}PASS${R}  $1"; }
+fail() { FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${R}  $1"; }
+assert_eq() { if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3 ${D}(expected '$2', got '$1')${R}"; fi; }
+assert_contains() { if echo "$1" | grep -qF -- "$2"; then pass "$3"; else fail "$3 ${D}(missing '$2')${R}"; fi; }
+section() { echo ""; echo -e "  ${CYN}${B}$1${R}"; }
+
+echo ""
+echo -e "  ${MAG}${B}================================================${R}"
+echo -e "  ${MAG}${B}  obsidian publishing tests${R}"
+echo -e "  ${MAG}${B}================================================${R}"
+
+# -- File existence ----------------------------------------
+section "File existence"
+[ -f "$PUBLISH_SCRIPT" ] && pass "publish-obsidian.sh exists" || fail "publish-obsidian.sh exists"
+[ -x "$PUBLISH_SCRIPT" ] && pass "publish-obsidian.sh is executable" || fail "publish-obsidian.sh is executable"
+[ -f "$TEST_SCRIPT" ] && pass "test-obsidian.sh exists" || fail "test-obsidian.sh exists"
+[ -x "$TEST_SCRIPT" ] && pass "test-obsidian.sh is executable" || fail "test-obsidian.sh is executable"
+[ -f "$SCRIPT_DIR/scripts/publish-obsidian.ps1" ] && pass "publish-obsidian.ps1 exists" || fail "publish-obsidian.ps1 exists"
+[ -f "$SCRIPT_DIR/scripts/test-obsidian.ps1" ] && pass "test-obsidian.ps1 exists" || fail "test-obsidian.ps1 exists"
+
+# -- Bash syntax -------------------------------------------
+section "Bash syntax"
+if bash -n "$PUBLISH_SCRIPT" 2>/dev/null; then
+  pass "publish-obsidian.sh valid bash syntax"
+else
+  fail "publish-obsidian.sh valid bash syntax"
+fi
+if bash -n "$TEST_SCRIPT" 2>/dev/null; then
+  pass "test-obsidian.sh valid bash syntax"
+else
+  fail "test-obsidian.sh valid bash syntax"
+fi
+
+# -- Publish script structure ------------------------------
+section "Publish script structure"
+pub=$(cat "$PUBLISH_SCRIPT")
+assert_contains "$pub" "set -euo pipefail" "publish: uses strict mode"
+assert_contains "$pub" "AI-News-Briefings" "publish: creates briefings subdirectory"
+assert_contains "$pub" "Topics" "publish: creates topics subdirectory"
+assert_contains "$pub" "OBSIDIAN_VAULT" "publish: reads vault env var"
+assert_contains "$pub" "mkdir" "publish: creates directories if missing"
+assert_contains "$pub" "cp " "publish: copies markdown file"
+
+# -- Wikilink extraction -----------------------------------
+section "Wikilink extraction logic"
+assert_contains "$pub" "grep" "publish: uses grep for wikilink extraction"
+assert_contains "$pub" "[[" "publish: extracts [[ patterns"
+assert_contains "$pub" "type: topic" "publish: generates YAML topic type for stubs"
+
+# -- Error handling ----------------------------------------
+section "Error handling"
+assert_contains "$pub" "exit 1" "publish: exits on error"
+
+# Test missing file argument
+err_output=$(AI_BRIEFING_OBSIDIAN_VAULT="/nonexistent" bash "$PUBLISH_SCRIPT" --file "/nonexistent/file.md" 2>&1) || true
+assert_contains "$err_output" "not found" "publish: reports missing file error"
+
+# Test missing vault (unset env var)
+TEMP_FILE=$(mktemp)
+echo "test" > "$TEMP_FILE"
+err_output=$(unset AI_BRIEFING_OBSIDIAN_VAULT; bash "$PUBLISH_SCRIPT" --file "$TEMP_FILE" 2>&1) || true
+assert_contains "$err_output" "not set" "publish: reports missing vault env var"
+rm -f "$TEMP_FILE"
+
+# -- Test script structure ---------------------------------
+section "Test script structure"
+test_scr=$(cat "$TEST_SCRIPT")
+assert_contains "$test_scr" "OBSIDIAN_VAULT" "test: checks vault env var"
+assert_contains "$test_scr" ".obsidian" "test: checks for .obsidian config dir"
+assert_contains "$test_scr" "writable" "test: checks vault writability"
+
+# -- Vault directory simulation ----------------------------
+section "Vault directory simulation"
+TEMP_VAULT=$(mktemp -d)
+TEMP_MD=$(mktemp)
+
+cat > "$TEMP_MD" << 'EOF'
+---
+date: 2026-04-11
+type: daily-briefing
+tags: [ai-news, daily]
+---
+
+# AI Daily Briefing — 2026-04-11
+
+Related topics: [[Claude Code]], [[OpenAI]], [[AI Coding IDEs]]
+
+## [[Claude Code]] / [[Anthropic]]
+
+Big news about [[Claude Code]] today.
+
+## [[OpenAI]] / [[GPT-5]]
+
+Updates from [[OpenAI]] on their latest model.
+EOF
+
+# Run publish with simulated vault
+mkdir -p "$TEMP_VAULT/.obsidian"
+output=$(AI_BRIEFING_OBSIDIAN_VAULT="$TEMP_VAULT" bash "$PUBLISH_SCRIPT" --file "$TEMP_MD" 2>&1) || true
+
+# Verify briefings directory created
+[ -d "$TEMP_VAULT/AI-News-Briefings" ] && pass "vault sim: AI-News-Briefings/ created" || fail "vault sim: AI-News-Briefings/ created"
+
+# Verify topics directory created
+[ -d "$TEMP_VAULT/Topics" ] && pass "vault sim: Topics/ created" || fail "vault sim: Topics/ created"
+
+# Verify briefing file was copied
+copied_files=$(ls "$TEMP_VAULT/AI-News-Briefings/" 2>/dev/null | wc -l)
+if [[ "$copied_files" -gt 0 ]]; then
+  pass "vault sim: briefing file copied to vault"
+else
+  fail "vault sim: briefing file copied to vault"
+fi
+
+# Verify topic stubs were created
+topic_count=$(ls "$TEMP_VAULT/Topics/" 2>/dev/null | wc -l)
+if [[ "$topic_count" -ge 3 ]]; then
+  pass "vault sim: topic stubs created ($topic_count topics)"
+else
+  fail "vault sim: topic stubs created ${D}(expected ≥3, got $topic_count)${R}"
+fi
+
+# Verify at least one expected topic stub exists
+if [ -f "$TEMP_VAULT/Topics/Claude Code.md" ]; then
+  pass "vault sim: Claude Code.md topic stub exists"
+  stub_content=$(cat "$TEMP_VAULT/Topics/Claude Code.md")
+  assert_contains "$stub_content" "type: topic" "vault sim: topic stub has type: topic frontmatter"
+else
+  fail "vault sim: Claude Code.md topic stub exists"
+fi
+
+# Verify idempotency — running again should not fail
+output2=$(AI_BRIEFING_OBSIDIAN_VAULT="$TEMP_VAULT" bash "$PUBLISH_SCRIPT" --file "$TEMP_MD" 2>&1) || true
+if [[ $? -eq 0 ]] || echo "$output2" | grep -qi "success\|copied\|exist"; then
+  pass "vault sim: idempotent re-run succeeds"
+else
+  fail "vault sim: idempotent re-run succeeds"
+fi
+
+# Cleanup temp files
+rm -rf "$TEMP_VAULT" "$TEMP_MD"
+
+# -- Summary -----------------------------------------------
+echo ""
+echo -e "  ${D}================================================${R}"
+if [[ "$FAIL" -eq 0 ]]; then
+  echo -e "  ${GRN}${B}ALL PASSED${R}  ${GRN}$PASS tests${R}"
+else
+  echo -e "  ${RED}${B}$FAIL FAILED${R}  ${D}($PASS passed)${R}"
+fi
+echo -e "  ${D}================================================${R}"
+echo ""
+
+exit "$FAIL"


### PR DESCRIPTION
This pull request significantly expands the system's documentation to cover new support for Obsidian as a publishing and knowledge graph platform, alongside existing integrations with Notion, Teams, and Slack. The changes include a detailed architectural overview of the Obsidian publishing pipeline, updates to CLI parameters and test coverage, and new documentation of supporting scripts and error handling. The test suite and usage instructions have also been updated to reflect the new functionality.

**Obsidian Integration and Publishing Pipeline:**

- Added full documentation for Obsidian support, including a new publishing pipeline that outputs graph-ready markdown files with `[[wikilinks]]`, copies them to a configured vault, and generates topic stub pages to build a knowledge graph in Obsidian. This includes architecture diagrams, file descriptions, environment variables, and error handling strategies. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR655-R764) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR596-R600) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL614-R630) [[4]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL628-R639)
- Updated CLI documentation and examples to include new `--obsidian`/`-Obsidian` parameters for both Bash and PowerShell scripts, and described new log file outputs (`*-obsidian.md`). [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL614-R630) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1149-R1265) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR655-R764)

**Documentation and Diagrams:**

- Revised all architecture diagrams and flowcharts to show Obsidian as an output option, including new nodes and flows for Obsidian markdown generation, publishing scripts, and vault/topic stub creation. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR82) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR96-R100) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1094-R1095) [[4]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1112) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1146-R1156)
- Updated badges and introductory sections to reflect Obsidian integration as a first-class feature. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR12) [[2]](diffhunk://#diff-4540f15063a107d68efcfbf7ed5a75cde35a8e9e549558405edc1a263ea59f55L3-R3)

**Test Suite and Coverage:**

- Added a dedicated test suite for Obsidian publishing (`test-obsidian.sh`/`.ps1`), expanded test counts, and updated test architecture diagrams to reflect increased coverage for Obsidian-related features. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR655-R764) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR776-R777) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL695-R803)

**Supporting Scripts and Files:**

- Documented new scripts for Obsidian publishing and testing (`publish-obsidian.sh`, `publish-obsidian.ps1`, `test-obsidian.sh`, `test-obsidian.ps1`), with details on their roles, platforms, and requirements. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR655-R764) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1146-R1156)

**Miscellaneous Improvements:**

- Updated feature comparison tables, environment variable documentation, and error handling sections to include Obsidian and clarify its security model (no secrets required). [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1088-R1209) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1237)
- Adjusted passing test counts to reflect the expanded test suite. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL23-R30) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR655-R764)

These updates ensure that Obsidian is fully documented as a supported publishing target, with clear instructions, diagrams, and robust test coverage.