### PR TITLE
Update CI workflow name for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 🔬 CI
+name: 🔬 CI Pipeline for AI News Briefing Research Ops System
 
 on:
   push:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The workflow name has been changed to better reflect its purpose as the CI pipeline for the AI News Briefing Research Ops System.