### PR TITLE
feat: add Docker support with Dockerfile, compose config, and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,11 +170,35 @@ jobs:
           done
           exit $status
 
+  # ── Job 6: Docker → GHCR ────────────────────────────────────
+  docker:
+    name: "🐳 Docker → GHCR"
+    needs: [test-bash, validate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/ai-news-briefing:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/ai-news-briefing:latest
+
   # ── Summary ─────────────────────────────────────────────────
   summary:
     name: 📊 Summary
     if: always()
-    needs: [lint, test-bash, test-powershell, validate, docs]
+    needs: [lint, test-bash, test-powershell, validate, docs, docker]
     runs-on: ubuntu-latest
     steps:
       - name: Pipeline results
@@ -189,13 +213,15 @@ jobs:
           | 🪟 Test (PowerShell) | `${{ needs.test-powershell.result }}` |
           | ✅ Validate | `${{ needs.validate.result }}` |
           | 📚 Docs | `${{ needs.docs.result }}` |
+          | 🐳 Docker | `${{ needs.docker.result }}` |
           EOF
 
           # Fail if any required job failed (lint excluded — advisory only)
           if [[ "${{ needs.test-bash.result }}" == "failure" ]] || \
              [[ "${{ needs.test-powershell.result }}" == "failure" ]] || \
              [[ "${{ needs.validate.result }}" == "failure" ]] || \
-             [[ "${{ needs.docs.result }}" == "failure" ]]; then
+             [[ "${{ needs.docs.result }}" == "failure" ]] || \
+             [[ "${{ needs.docker.result }}" == "failure" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> [!CAUTION]" >> "$GITHUB_STEP_SUMMARY"
             echo "> Some checks failed." >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use a lightweight Ubuntu base image
+FROM ubuntu:22.04
+
+# Avoid tzdata interactive prompt and install dependencies
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    curl \
+    git \
+    python3 \
+    make \
+    ca-certificates \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy all project files
+COPY . .
+
+# Ensure all scripts are executable
+RUN chmod +x briefing.sh custom-brief.sh scripts/*.sh
+
+# Default to running the briefing script
+ENTRYPOINT ["bash", "briefing.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  briefing:
+    build: .
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ai-news-briefing:latest
+    volumes:
+      # Mount Claude auth configuration
+      - ~/.config/claude:/root/.config/claude
+      # Mount workspace for local execution
+      - .:/app
+    env_file:
+      - .env
+    command: bash briefing.sh


### PR DESCRIPTION
This pull request introduces Docker support for the project, enabling containerized builds and automated publishing to GitHub Container Registry (GHCR) as part of the CI workflow. It adds a `Dockerfile` and `docker-compose.yml` for local development and deployment, and updates the CI pipeline to build, push, and track Docker image results.

**Docker support and deployment:**

* Added a `Dockerfile` that defines a lightweight Ubuntu-based image, installs necessary dependencies, copies project files, ensures scripts are executable, and sets the default entrypoint to run `briefing.sh`.
* Added a `docker-compose.yml` file to simplify local development and testing with Docker, including mounting configuration and workspace directories, and supporting environment variables.

**CI/CD pipeline enhancements:**

* Introduced a new `docker` job in `.github/workflows/ci.yml` to build and push Docker images to GHCR, using the official Docker GitHub Actions and tagging images with both the commit SHA and `latest`.
* Updated the `summary` job in the CI workflow to depend on the new `docker` job and to display the Docker job result in the pipeline summary. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR173-R201) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR216-R224)
* Modified the CI failure detection logic to include the Docker job, so the workflow summary accurately reflects Docker build/push failures.