### PR TITLE
Implement LLM-as-judge evaluation harness for briefing quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ backups/
 .vs/
 .claude/
 __pycache__/
+eval/store.sqlite
+eval/store.sqlite-journal
+eval/store.sqlite-wal
+eval/store.sqlite-shm

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,11 @@
+# Security contact for AI News Briefing
+# Spec: https://www.rfc-editor.org/rfc/rfc9116
+# Project: https://github.com/hoangsonww/AI-News-Briefing
+
+Contact: https://github.com/hoangsonww/AI-News-Briefing/security/advisories/new
+Contact: mailto:hoangson091104@gmail.com
+Expires: 2027-05-13T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://hoangsonww.github.io/AI-News-Briefing/.well-known/security.txt
+Policy: https://github.com/hoangsonww/AI-News-Briefing/security/policy
+Acknowledgments: https://github.com/hoangsonww/AI-News-Briefing/blob/main/README.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -818,6 +818,111 @@ flowchart TD
 
 Full documentation: [TESTS.md](TESTS.md)
 
+### 3.14 Quality Eval Harness (`eval/`)
+
+A self-contained LLM-as-judge pipeline that scores every published briefing on a fixed 5-axis rubric, persists scores to SQLite, and flags quality drift before readers notice. The harness reuses the same AI CLIs the rest of the project shells out to (`claude` / `codex` / `gemini`) so it inherits the project's existing auth and engine selection.
+
+#### Architecture
+
+```mermaid
+flowchart TD
+    subgraph "Inputs"
+        CARD["example-cards/&lt;date&gt;-card.json<br/>(Teams Adaptive Card)"]
+        PRIOR["Prior 7 days of cards<br/>(novelty baseline)"]
+    end
+
+    subgraph "Harness (eval/)"
+        EX["extract.py<br/>Card → text + headlines + URLs"]
+        JU["judge.py<br/>backends: stub/claude/codex/gemini"]
+        ST["store.py<br/>SQLite upsert (date, prompt_ver, model)"]
+        DR["drift.py<br/>7d median vs 30d median ± MAD"]
+        RP["report.py<br/>Weekly Markdown digest"]
+        RUN["runner.py<br/>CLI: score / backfill / regression"]
+    end
+
+    subgraph "State"
+        DB[("eval/store.sqlite<br/>eval_runs table")]
+        GOLD["eval/golden/*.json<br/>baseline composites"]
+    end
+
+    subgraph "Consumers"
+        GATE["Publish gate<br/>(briefing.sh, optional)"]
+        ALERT["Drift alert<br/>(cron / GH Actions)"]
+        DASH["Weekly report<br/>(Notion / Teams)"]
+    end
+
+    CARD --> EX
+    PRIOR --> EX
+    EX --> JU --> RUN --> ST --> DB
+
+    GOLD --> RUN
+    DB --> DR --> ALERT
+    DB --> RP --> DASH
+    RUN -- "--gate" --> GATE
+```
+
+#### Scoring rubric
+
+Five integer axes (1–5), composite weighted mean:
+
+| Axis             | Weight |
+| ---------------- | -----: |
+| factuality       |   0.30 |
+| novelty          |   0.20 |
+| source_diversity |   0.15 |
+| signal_density   |   0.20 |
+| coherence        |   0.15 |
+
+Full definitions and pass thresholds: [`eval/rubric.md`](eval/rubric.md).
+
+#### Storage schema
+
+```sql
+CREATE TABLE eval_runs (
+    card_date        TEXT,
+    prompt_version   TEXT,
+    judge_model      TEXT,
+    ran_at           TEXT,
+    factuality       INTEGER CHECK (BETWEEN 1 AND 5),
+    novelty          INTEGER CHECK (BETWEEN 1 AND 5),
+    source_diversity INTEGER CHECK (BETWEEN 1 AND 5),
+    signal_density   INTEGER CHECK (BETWEEN 1 AND 5),
+    coherence        INTEGER CHECK (BETWEEN 1 AND 5),
+    composite        REAL,
+    notes            TEXT,
+    judge_raw        TEXT,
+    PRIMARY KEY (card_date, prompt_version, judge_model)
+);
+```
+
+The primary key intentionally includes both `prompt_version` and `judge_model`, so re-baselining (bumping the prompt or switching to a more capable judge) appends a new row rather than silently overwriting historic scores.
+
+#### Design decisions
+
+- **Stub backend.** A deterministic heuristic judge ships in `judge.py` so unit tests, CI, and offline development never hit a paid API. The same harness paths execute against the real judge.
+- **Median + MAD for drift, not mean + stddev.** With only ~30 daily samples and occasional sharp drops, MAD-based z-scores are far more robust to outliers and small-sample bias than parametric scaling.
+- **Idempotent runs.** Re-judging the same `(date, prompt_version, judge_model)` triple overwrites the row and updates `ran_at`, so reruns after a transient failure produce a clean store.
+- **Versioned prompt.** `PROMPT_VERSION` in `judge.py` is part of the key and is recorded with every score. Bump it whenever `eval/judge_prompt.md` changes substantively.
+- **Optional publish gate.** Calling `runner.py score --gate` exits non-zero when composite falls below threshold, so it can be wired into `briefing.sh` as a pre-publish check without changing default behavior.
+
+#### Files
+
+| File              | Role                                                       |
+| ----------------- | ---------------------------------------------------------- |
+| `rubric.md`       | Human-readable axis definitions, weights, thresholds.      |
+| `judge_prompt.md` | Exact prompt sent to the judge. Versioned.                 |
+| `extract.py`      | Adaptive-card JSON → flat text, headlines, source URLs.    |
+| `judge.py`        | Backends (stub / claude / codex / gemini) + JSON parser.   |
+| `store.py`        | SQLite upsert/fetch + composite formula.                   |
+| `runner.py`       | CLI entry point: `score`, `backfill`, `regression`, `show`.|
+| `drift.py`        | Trailing-window drift detector.                            |
+| `report.py`       | Weekly Markdown report.                                    |
+| `schema.sql`      | DB schema.                                                 |
+| `golden/`         | Pinned baseline composites per card.                       |
+| `tests/`          | `python -m unittest discover -s eval/tests`.               |
+
+Full documentation: [`eval/README.md`](eval/README.md).
+
 ---
 
 ## 4. Data Flow

--- a/E2E_FLOW.md
+++ b/E2E_FLOW.md
@@ -280,6 +280,37 @@ The prompt and runtime pipeline are aligned on a shared card artifact and dual-c
 Additionally, `prompt.md` Step 3 now prevents duplicate Notion pages by checking for an existing page during Step 0b and updating rather than creating when one is found.
 Current `briefing.sh` and `briefing.ps1` invoke both notifiers in all-URL mode (`--all` / `-All`) when the corresponding env vars are set.
 
+### Stage E: Quality Eval (post-publish)
+
+After the card is written, the eval harness in `eval/` judges the briefing on a 5-axis rubric and persists the score:
+
+```mermaid
+flowchart LR
+    CARD["logs/YYYY-MM-DD-card.json<br/>(or example-cards/&lt;date&gt;-card.json)"]
+    PRIOR["Prior 7 days of cards"]
+    RUN["eval/runner.py score<br/>--judge claude --gate (optional)"]
+    JUDGE["AI CLI (claude/codex/gemini)<br/>or stub backend"]
+    DB[("eval/store.sqlite")]
+    DRIFT["eval/drift.py<br/>nightly cron"]
+    GATE{"composite ≥ 3.0?"}
+    PUB["Publish step proceeds"]
+    BLOCK["Block publish, log reason"]
+
+    CARD --> RUN
+    PRIOR --> RUN
+    RUN --> JUDGE --> RUN --> DB
+    DB --> DRIFT
+    RUN -- "--gate" --> GATE
+    GATE -- yes --> PUB
+    GATE -- no --> BLOCK
+```
+
+Behavior contract:
+
+- **No `--gate` flag (default):** the harness is observational. It writes a row to `eval_runs` and exits 0. Existing pipelines are unchanged.
+- **With `--gate --gate-threshold 3.0`:** the harness exits 2 when composite is below threshold, allowing the caller (e.g. `briefing.sh`) to abort the Notion/Teams/Slack publish step.
+- **Idempotent:** re-running the same `(card_date, prompt_version, judge_model)` overwrites the row. Bumping the prompt version or switching judge model appends rather than overwrites.
+
 ---
 
 ## 6. Failure-State Diagram

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run run-bg custom-brief custom-brief-bg tail log logs status install uninstall clean-logs check validate prompt eval eval-backfill eval-regression eval-drift eval-report eval-show eval-test
+.PHONY: help run run-bg custom-brief custom-brief-bg tail log logs status install uninstall clean-logs check validate prompt eval eval-backfill eval-regression eval-seed-golden eval-drift eval-report eval-show eval-test
 
 SHELL := /bin/bash
 DATE  := $(shell date +%Y-%m-%d)
@@ -263,6 +263,11 @@ eval-backfill: ## Score every card in example-cards/. JUDGE=stub by default
 
 eval-regression: ## Re-score golden cards, fail if composite drops > 0.5
 	@python3 "$(SCRIPT_DIR)/eval/runner.py" regression --judge $(JUDGE)
+
+eval-seed-golden: ## Seed eval/golden/ from store.sqlite. Options: JUDGE=<judge_model> CLEAN=1
+	@python3 "$(SCRIPT_DIR)/eval/seed_golden.py" \
+		$(if $(filter-out stub,$(JUDGE)),--judge claude-haiku-4-5-20251001) \
+		$(if $(CLEAN),--clean)
 
 eval-drift: ## Drift check. Options: D=YYYY-MM-DD ALERT_EXIT=1
 	@python3 "$(SCRIPT_DIR)/eval/drift.py" \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run run-bg custom-brief custom-brief-bg tail log logs status install uninstall clean-logs check validate prompt
+.PHONY: help run run-bg custom-brief custom-brief-bg tail log logs status install uninstall clean-logs check validate prompt eval eval-backfill eval-regression eval-drift eval-report eval-show eval-test
 
 SHELL := /bin/bash
 DATE  := $(shell date +%Y-%m-%d)
@@ -247,6 +247,39 @@ validate: check ## Validate all project files exist and are well-formed
 
 prompt: ## Print the current prompt
 	@cat "$(SCRIPT_DIR)/prompt.md"
+
+## —— Eval Harness ————————————————————————————————————
+# JUDGE selects the backend: stub (default, no API), claude, codex, gemini.
+JUDGE ?= stub
+
+eval: ## Score today's card. Options: D=YYYY-MM-DD JUDGE=stub|claude|codex|gemini GATE=1
+	@python3 "$(SCRIPT_DIR)/eval/runner.py" score \
+		--date $(or $(D),$(DATE)) \
+		--judge $(JUDGE) \
+		$(if $(GATE),--gate)
+
+eval-backfill: ## Score every card in example-cards/. JUDGE=stub by default
+	@python3 "$(SCRIPT_DIR)/eval/runner.py" backfill --judge $(JUDGE)
+
+eval-regression: ## Re-score golden cards, fail if composite drops > 0.5
+	@python3 "$(SCRIPT_DIR)/eval/runner.py" regression --judge $(JUDGE)
+
+eval-drift: ## Drift check. Options: D=YYYY-MM-DD ALERT_EXIT=1
+	@python3 "$(SCRIPT_DIR)/eval/drift.py" \
+		--as-of $(or $(D),$(DATE)) \
+		$(if $(ALERT_EXIT),--exit-nonzero-on-alert)
+
+eval-report: ## Weekly Markdown report. Options: D=YYYY-MM-DD W=7 OUT=path
+	@python3 "$(SCRIPT_DIR)/eval/report.py" \
+		--as-of $(or $(D),$(DATE)) \
+		--window $(or $(W),7) \
+		$(if $(OUT),--out $(OUT))
+
+eval-show: ## Dump stored eval rows
+	@python3 "$(SCRIPT_DIR)/eval/runner.py" show
+
+eval-test: ## Run unit tests for the eval harness
+	@python3 -m unittest discover -s "$(SCRIPT_DIR)/eval/tests" -v
 
 ## —— Info —————————————————————————————————————————————
 info: ## Show project configuration summary

--- a/README.md
+++ b/README.md
@@ -330,6 +330,13 @@ The project includes a cross-platform `Makefile` that auto-detects your OS and r
 | `make validate` | Validate all project files and prompt structure |
 | `make prompt` | Print the current prompt |
 | `make info` | Show config summary (engines, model, paths) |
+| `make eval D=YYYY-MM-DD JUDGE=stub\|claude\|codex\|gemini [GATE=1]` | Judge one card on the 5-axis rubric |
+| `make eval-backfill JUDGE=stub` | Score every card in `example-cards/` |
+| `make eval-regression JUDGE=claude` | Re-score golden set, fail on > 0.5 composite drop |
+| `make eval-drift D=YYYY-MM-DD [ALERT_EXIT=1]` | Rolling-window drift detector |
+| `make eval-report D=YYYY-MM-DD W=7 [OUT=path]` | Weekly Markdown report |
+| `make eval-show` | Dump stored eval rows |
+| `make eval-test` | Run eval-harness unit tests |
 | `CLI=<engine>` | Parameter: choose engine (`claude`, `codex`, `gemini`, `copilot`) |
 
 ### Utility Scripts Reference
@@ -692,6 +699,35 @@ Full documentation: [TESTS.md](TESTS.md)
 
 ---
 
+## Quality Eval Harness
+
+Every published briefing is silently judged by an LLM-as-judge on a 5-axis rubric so we can detect quality drift before readers notice it. The harness lives in `eval/` and is fully offline-testable via a `stub` backend that exercises the full pipeline without burning API credits.
+
+**Axes** (composite = weighted mean):
+
+| Axis             | Weight | What it measures                                   |
+| ---------------- | -----: | -------------------------------------------------- |
+| factuality       |   0.30 | Concrete claims map to cited sources               |
+| novelty          |   0.20 | New vs. prior 7-day window of cards                |
+| source_diversity |   0.15 | Domain spread, primary + secondary mix             |
+| signal_density   |   0.20 | Numbers, named entities, concrete outcomes         |
+| coherence        |   0.15 | Thematic grouping, not bullet soup                 |
+
+**Pipelines provided:**
+
+- **Score** — `make eval D=YYYY-MM-DD JUDGE=claude` writes a row to `eval/store.sqlite`.
+- **Backfill** — `make eval-backfill` scores every card under `example-cards/`.
+- **Regression** — `make eval-regression` re-scores the golden set in `eval/golden/` and fails if any card drops more than 0.5 composite points vs. its pinned baseline.
+- **Drift** — `make eval-drift D=YYYY-MM-DD ALERT_EXIT=1` alerts when the trailing-7d median falls more than 1.5 MADs below the trailing-30d median for two consecutive days.
+- **Report** — `make eval-report D=YYYY-MM-DD W=7` emits a Markdown weekly digest.
+- **Publish gate** (optional) — invoke `runner.py score --gate --gate-threshold 3.0` ahead of the publish step to block low-quality briefings.
+
+Judge backends shell out to the existing CLIs (`claude` / `codex` / `gemini`) so no new auth is required. Default judge model is `claude-haiku-4-5-20251001` (~$0.002/card). The store schema is keyed on `(card_date, prompt_version, judge_model)`, so bumping the rubric or switching judges keeps history rather than overwriting it.
+
+Full documentation: [eval/README.md](eval/README.md).
+
+---
+
 ## Troubleshooting
 
 ### "Claude Code cannot be launched inside another Claude Code session"
@@ -809,6 +845,19 @@ ai-news-briefing/
 │   └── test-all.ps1             # PowerShell test suite
 ├── logs/                        # Run logs (git-ignored)
 ├── backups/                     # Prompt backups (git-ignored)
+├── eval/                        # Quality eval harness (LLM-as-judge)
+│   ├── README.md                # Harness documentation
+│   ├── rubric.md                # 5-axis rubric + weights + thresholds
+│   ├── judge_prompt.md          # Versioned judge prompt
+│   ├── schema.sql               # SQLite schema for eval_runs
+│   ├── extract.py               # Adaptive-card JSON -> text/headlines/URLs
+│   ├── judge.py                 # Backends: stub/claude/codex/gemini
+│   ├── store.py                 # Upsert + fetch + composite formula
+│   ├── runner.py                # CLI: score / backfill / regression / show
+│   ├── drift.py                 # Trailing-window drift detector
+│   ├── report.py                # Weekly Markdown report builder
+│   ├── golden/                  # Pinned baseline composites per card
+│   └── tests/                   # Unit tests for the harness
 ├── .gitignore
 ├── ARCHITECTURE.md              # Detailed architecture documentation
 ├── E2E_FLOW.md                  # End-to-end pipeline walkthrough

--- a/TESTS.md
+++ b/TESTS.md
@@ -82,7 +82,15 @@ powershell -ExecutionPolicy Bypass -File tests\test-all.ps1
 
 ### From Make
 
-There is no Make target for tests (tests are not part of the daily pipeline). Run them directly via bash or PowerShell.
+The shell + PowerShell suites have no Make target (they are not part of the daily pipeline). Run them directly via bash or PowerShell.
+
+The Python eval-harness tests do have a Make target:
+
+```bash
+make eval-test          # python -m unittest discover -s eval/tests
+```
+
+These exercise the offline `stub` judge end-to-end (extract → judge → store → drift → report) and require only Python 3 stdlib.
 
 ---
 
@@ -238,6 +246,36 @@ flowchart LR
 | Notify invocation | 4 | Uses `-f` not `-x`, calls via `bash` not direct execution |
 | Color safety | 1 | No raw ANSI escapes when output is piped |
 
+### eval/tests/test_harness.py (10 tests)
+
+Python unit tests for the quality eval harness. Use only the Python stdlib and the offline `stub` judge, so they require no AI CLI and no network.
+
+```mermaid
+flowchart LR
+    subgraph "eval/tests/test_harness.py"
+        A["ExtractTests"] --> B["JudgeTests"]
+        B --> C["StoreTests"]
+        C --> D["DriftTests"]
+        D --> E["ReportTests"]
+    end
+```
+
+| Category | Tests | What it verifies |
+|---|---|---|
+| ExtractTests | 2 | Card → headlines + URLs; 7-day prior-headline window resolves |
+| JudgeTests | 3 | Stub returns 5 valid axes; parser rejects non-JSON; parser rejects out-of-range scores |
+| StoreTests | 2 | Weighted composite matches the rubric formula; upsert is idempotent on `(card_date, prompt_version, judge_model)` |
+| DriftTests | 2 | Flat history → no alert; 8-day drop streak → `status: alert` with ≥ 2 alert entries |
+| ReportTests | 1 | Weekly Markdown contains header, composite-median line, and per-day row |
+
+Run via:
+
+```bash
+make eval-test
+# or directly
+python3 -m unittest discover -s eval/tests -v
+```
+
 ### test-all.ps1 (91 tests)
 
 PowerShell-native test suite covering everything above from a Windows perspective.
@@ -318,6 +356,9 @@ tests/
   test-obsidian.sh         # Obsidian: publish script, wikilinks, vault simulation
   test-portability.sh      # Cross-platform: bash compat, awk, date, colors
   test-all.ps1             # PowerShell suite (all categories in one file)
+
+eval/tests/
+  test_harness.py          # Python unittest: extract, judge, store, drift, report
 ```
 
 ---

--- a/eval/README.md
+++ b/eval/README.md
@@ -65,18 +65,57 @@ combination overwrite; switching judge or prompt version appends a new row.
 
 ## Golden set
 
-`eval/golden/*.json` — each file pins a `card_date` + `baseline_composite`.
-`make eval-regression` re-scores them and exits 2 if any drops more than
-0.5 composite points. Bump the baselines when re-scoring under a new judge:
+`eval/golden/*.json` — one file per card_date, each pinning the baseline
+composite + axis scores from the most recent intentional rebaseline. `make
+eval-regression` re-scores them and exits 2 if any drops more than 0.5
+composite points.
+
+The shipping golden set is the **full 18-card backfill** under
+`claude-haiku-4-5-20251001` v1 (real-judge composites span 2.9–4.2), so the
+regression gate catches degradation across the entire history, not just a
+hand-picked subset.
+
+Each file looks like:
 
 ```json
 {
   "card_date": "2026-03-18",
-  "baseline_composite": 4.2,
+  "baseline_composite": 4.0,
   "baseline_judge": "claude-haiku-4-5-20251001",
-  "baseline_prompt_version": "v1"
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:51:27+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 4
+  },
+  "notes": "Novelty drags from GPT-5.4 mini pricing (prior week)."
 }
 ```
+
+### Re-baselining
+
+When you intentionally change the judge prompt, switch to a more capable
+judge, or otherwise rebase quality expectations, regenerate the goldens
+from the store rather than hand-editing the JSON:
+
+```bash
+# 1. Run the new judge/prompt against every card
+make eval-backfill JUDGE=claude
+
+# 2. Lift the resulting scores into the golden set
+make eval-seed-golden JUDGE=claude       # latest-per-date, filtered to the real judge
+# or with --clean to wipe stale dates that no longer exist
+make eval-seed-golden JUDGE=claude CLEAN=1
+
+# 3. Verify the new gate passes
+make eval-regression JUDGE=claude
+```
+
+`eval/seed_golden.py` supports `--since`, `--until`, `--judge`,
+`--prompt-version`, `--dry-run`, and `--clean` for finer control.
 
 ## Drift detection
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,123 @@
+# Briefing Quality Eval Harness
+
+LLM-as-judge scoring for daily AI News Briefing cards. Tracks composite quality
+over time, runs a regression guard against a golden set, and surfaces drift
+before it ships to readers.
+
+## What it scores
+
+Five axes, integer 1–5 each (rubric in [`rubric.md`](rubric.md)):
+
+| Axis             | Weight |
+| ---------------- | -----: |
+| factuality       |   0.30 |
+| novelty          |   0.20 |
+| source_diversity |   0.15 |
+| signal_density   |   0.20 |
+| coherence        |   0.15 |
+
+`composite = round(0.30·F + 0.20·N + 0.15·D + 0.20·S + 0.15·C, 2)`
+
+## Quick start
+
+```bash
+# Score today (stub judge, no API)
+make eval D=2026-03-18
+
+# Score with the real Claude judge (uses claude CLI like the rest of the project)
+make eval D=2026-03-18 JUDGE=claude
+
+# Backfill every card in example-cards/
+make eval-backfill
+
+# Weekly Markdown report
+make eval-report D=2026-03-18 W=7
+
+# Drift check, exit 3 on alert (use in cron)
+make eval-drift D=2026-03-18 ALERT_EXIT=1
+
+# Regression: re-score the golden cards, fail on > 0.5 drop
+make eval-regression JUDGE=claude
+
+# Run unit tests
+make eval-test
+```
+
+## How the judge is wired
+
+The harness shells out to whatever AI CLI you already use, matching the
+existing `briefing.sh` pattern. Backends:
+
+- `stub` — deterministic heuristic, used by tests and CI smoke runs.
+- `claude` — `claude -p --model $EVAL_JUDGE_MODEL` (default `claude-haiku-4-5-20251001`).
+- `codex` — `codex exec -`.
+- `gemini` — `gemini -p <prompt>`.
+
+The judge prompt is in [`judge_prompt.md`](judge_prompt.md). Its version
+(`PROMPT_VERSION` in `judge.py`) is part of the primary key, so bumping the
+prompt does **not** silently overwrite old scores.
+
+## Storage
+
+SQLite at `eval/store.sqlite` (git-ignored). Schema in `schema.sql`.
+Primary key: `(card_date, prompt_version, judge_model)` — re-runs of the same
+combination overwrite; switching judge or prompt version appends a new row.
+
+## Golden set
+
+`eval/golden/*.json` — each file pins a `card_date` + `baseline_composite`.
+`make eval-regression` re-scores them and exits 2 if any drops more than
+0.5 composite points. Bump the baselines when re-scoring under a new judge:
+
+```json
+{
+  "card_date": "2026-03-18",
+  "baseline_composite": 4.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1"
+}
+```
+
+## Drift detection
+
+`drift.py` compares the trailing-7d median composite to the trailing-30d
+median, scaled by MAD (robust to outliers). Alerts when
+
+  z = (short_med − long_med) / max(long_mad, 0.05) < −1.5
+
+for 2 consecutive days. Tune `--short-window`, `--long-window`,
+`--z-thresh`, `--streak`.
+
+## Publish gate (optional)
+
+To block a briefing publish on a quality fail, run scoring with `--gate` before
+the publish step:
+
+```bash
+python3 eval/runner.py score --date "$DATE" --judge claude --gate --gate-threshold 3.0 \
+  || { echo "Briefing failed eval gate, not publishing." >&2; exit 1; }
+```
+
+Exit codes: 0 = pass, 2 = gate fail, 1 = harness error.
+
+## Cost
+
+Judge runs use Claude Haiku by default (~$0.002/card). Daily + weekly golden
+replay (~25 calls/wk) ≈ $0.05/wk. Backfill caps at `--max-calls 50` (bump
+flag to override).
+
+## File map
+
+| File          | Role                                                   |
+| ------------- | ------------------------------------------------------ |
+| `rubric.md`   | Human-readable axis definitions, weights, thresholds.  |
+| `judge_prompt.md` | Exact prompt sent to the judge. Versioned.         |
+| `extract.py`  | Adaptive-card JSON → flat text + headlines + URLs.     |
+| `judge.py`    | Backends (stub/claude/codex/gemini) + JSON parser.     |
+| `store.py`    | SQLite upsert + fetch.                                 |
+| `runner.py`   | CLI: `score`, `backfill`, `regression`, `show`.        |
+| `drift.py`    | Rolling-window drift detector.                         |
+| `report.py`   | Weekly Markdown report.                                |
+| `schema.sql`  | DB schema.                                             |
+| `golden/`     | Pinned baseline composites per card.                   |
+| `tests/`      | `python -m unittest discover -s eval/tests`.           |

--- a/eval/drift.py
+++ b/eval/drift.py
@@ -1,0 +1,121 @@
+"""Drift detection over rolling composite scores.
+
+Heuristic: alert when the trailing-7d median is more than ``z_thresh``
+standard deviations below the trailing-30d median, for ``streak`` consecutive
+days. We use median + MAD-based scale to stay robust on small samples
+(18-card backfill is not enough for clean stddev).
+
+Run from the repo root:
+
+    python eval/drift.py --as-of 2026-03-18
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from store import fetch_runs  # noqa: E402
+
+
+def _median_and_mad(xs: list[float]) -> tuple[float, float]:
+    if not xs:
+        return 0.0, 0.0
+    med = statistics.median(xs)
+    mad = statistics.median(abs(x - med) for x in xs)
+    return med, mad
+
+
+def _date_range(end: date, days: int) -> list[str]:
+    return [(end - timedelta(days=i)).isoformat() for i in range(days)]
+
+
+def evaluate(as_of: str, *, short_window: int = 7, long_window: int = 30,
+             z_thresh: float = 1.5, streak: int = 2) -> dict:
+    y, m, d = (int(x) for x in as_of.split("-"))
+    end = date(y, m, d)
+    long_dates = set(_date_range(end, long_window))
+    rows = fetch_runs(since=min(long_dates), until=max(long_dates) if long_dates else None)
+    if not rows:
+        return {"as_of": as_of, "status": "no_data", "alerts": []}
+
+    # If multiple judge runs exist for a date, prefer the latest run.
+    by_date: dict[str, float] = {}
+    latest_at: dict[str, str] = {}
+    for r in rows:
+        d = r["card_date"]
+        if d not in latest_at or r["ran_at"] > latest_at[d]:
+            latest_at[d] = r["ran_at"]
+            by_date[d] = r["composite"]
+
+    alerts: list[dict] = []
+    bad_days = 0
+    for i in range(streak):
+        check_day = (end - timedelta(days=i)).isoformat()
+        short_xs = [
+            by_date[d.isoformat()]
+            for d in (end - timedelta(days=i + k) for k in range(short_window))
+            if d.isoformat() in by_date
+        ]
+        long_xs = [
+            by_date[d.isoformat()]
+            for d in (end - timedelta(days=i + k) for k in range(long_window))
+            if d.isoformat() in by_date
+        ]
+        if len(short_xs) < 3 or len(long_xs) < 7:
+            continue
+        short_med = statistics.median(short_xs)
+        long_med, long_mad = _median_and_mad(long_xs)
+        scale = max(long_mad, 0.05)  # avoid div-by-zero
+        z = (short_med - long_med) / scale
+        if z < -z_thresh:
+            bad_days += 1
+            alerts.append({
+                "day": check_day,
+                "short_median": round(short_med, 2),
+                "long_median": round(long_med, 2),
+                "z": round(z, 2),
+            })
+
+    status = "alert" if bad_days >= streak else "ok"
+    return {
+        "as_of": as_of,
+        "status": status,
+        "short_window": short_window,
+        "long_window": long_window,
+        "z_thresh": z_thresh,
+        "streak_required": streak,
+        "alerts": alerts,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--as-of", required=True, help="YYYY-MM-DD")
+    p.add_argument("--short-window", type=int, default=7)
+    p.add_argument("--long-window", type=int, default=30)
+    p.add_argument("--z-thresh", type=float, default=1.5)
+    p.add_argument("--streak", type=int, default=2)
+    p.add_argument("--exit-nonzero-on-alert", action="store_true")
+    args = p.parse_args(argv)
+
+    result = evaluate(
+        args.as_of,
+        short_window=args.short_window,
+        long_window=args.long_window,
+        z_thresh=args.z_thresh,
+        streak=args.streak,
+    )
+    print(json.dumps(result, indent=2))
+    if args.exit_nonzero_on_alert and result["status"] == "alert":
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/extract.py
+++ b/eval/extract.py
@@ -1,0 +1,114 @@
+"""Extract plain-text briefing content from a Microsoft Teams adaptive card JSON.
+
+Cards live in ``example-cards/YYYY-MM-DD-card.json``. Each card has nested
+``Container``/``TextBlock`` items. We walk the tree and emit a flat text view
+that the judge model can score, plus a list of headline lines for novelty
+comparison against prior days.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+CARD_DIR_DEFAULT = Path(__file__).resolve().parent.parent / "example-cards"
+
+
+@dataclass
+class Briefing:
+    card_date: str
+    title: str
+    body_text: str
+    headlines: list[str]
+    source_urls: list[str]
+
+
+def _walk_textblocks(node, out: list[str]) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "TextBlock" and isinstance(node.get("text"), str):
+            out.append(node["text"])
+        for v in node.values():
+            _walk_textblocks(v, out)
+    elif isinstance(node, list):
+        for x in node:
+            _walk_textblocks(x, out)
+
+
+def _walk_actions(node, out: list[str]) -> None:
+    """Pull URLs from Action.OpenUrl entries (cards link to source articles)."""
+    if isinstance(node, dict):
+        if node.get("type") == "Action.OpenUrl" and isinstance(node.get("url"), str):
+            out.append(node["url"])
+        for v in node.values():
+            _walk_actions(v, out)
+    elif isinstance(node, list):
+        for x in node:
+            _walk_actions(x, out)
+
+
+_URL_RE = re.compile(r"https?://[^\s\)\]\>]+")
+
+
+def load_card(path: Path) -> Briefing:
+    card = json.loads(path.read_text())
+    texts: list[str] = []
+    urls: list[str] = []
+    _walk_textblocks(card, texts)
+    _walk_actions(card, urls)
+    # Pull any URLs embedded inline in TextBlocks too.
+    for t in texts:
+        urls.extend(_URL_RE.findall(t))
+
+    title = texts[0] if texts else ""
+    headlines = [t for t in texts if t.startswith("- ")]
+    body_text = "\n".join(texts)
+
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", path.name)
+    card_date = m.group(1) if m else ""
+
+    return Briefing(
+        card_date=card_date,
+        title=title,
+        body_text=body_text,
+        headlines=headlines,
+        source_urls=sorted(set(urls)),
+    )
+
+
+def prior_headlines(card_date: str, days: int = 7, card_dir: Path | None = None) -> list[str]:
+    """Return headlines from the N days *before* ``card_date`` (exclusive)."""
+    card_dir = card_dir or CARD_DIR_DEFAULT
+    y, m, d = (int(x) for x in card_date.split("-"))
+    target = date(y, m, d)
+    out: list[str] = []
+    for i in range(1, days + 1):
+        prev = target - timedelta(days=i)
+        p = card_dir / f"{prev.isoformat()}-card.json"
+        if p.exists():
+            try:
+                out.extend(load_card(p).headlines)
+            except Exception:
+                pass
+    return out
+
+
+def find_card(card_date: str, card_dir: Path | None = None) -> Path:
+    card_dir = card_dir or CARD_DIR_DEFAULT
+    p = card_dir / f"{card_date}-card.json"
+    if not p.exists():
+        raise FileNotFoundError(f"No card for {card_date} at {p}")
+    return p
+
+
+if __name__ == "__main__":  # quick manual check
+    import sys
+
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else find_card("2026-03-18")
+    b = load_card(path)
+    print(f"date={b.card_date} title={b.title!r}")
+    print(f"headlines={len(b.headlines)} urls={len(b.source_urls)}")
+    print(b.body_text[:400])

--- a/eval/golden/2026-03-01.json
+++ b/eval/golden/2026-03-01.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-01",
+  "baseline_composite": 3.7,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:15+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 4
+  },
+  "notes": "Sources listed but not inline-mapped; claims like '500+ zero-days detected' and '70% of Claude Code tests' lack verification paths. Feb 5 Claude Opus story (24 days old) appears in a daily briefing dated March 1, suggesting recycled content if featured prior week."
+}

--- a/eval/golden/2026-03-02.json
+++ b/eval/golden/2026-03-02.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-02",
+  "baseline_composite": 3.8,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:26+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "Most briefing items are follow-ups from prior week: Trump ban \u2192 Anthropic legal challenge, MWC preview \u2192 Day 0 coverage, DeepSeek V4 launch (already expected), Apple Siri iOS rollout (already in motion). New elements present (#QuitGPT 2.5M supporters, Claude App Store #1, London protest with Extinction Rebellion, Deutsche Telekom 6G Hub, Nvidia optical partnerships) but don't offset heavy rehash of Anthropic ban, Pentagon deal, MWC, and GPT-5 launch cycle."
+}

--- a/eval/golden/2026-03-03.json
+++ b/eval/golden/2026-03-03.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-03",
+  "baseline_composite": 3.25,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:03+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 2,
+    "source_diversity": 3,
+    "signal_density": 3,
+    "coherence": 4
+  },
+  "notes": "Novelty is lowest. #QuitGPT, OpenAI Pentagon deal, and DeepSeek V4 launch were all previewed in prior week; briefing largely reports the expected next chapters rather than new developments. Qwen 3.5 was also pre-announced. Strong topical organization and most claims have sources, but limited signal density on OpenAI safeguards and Samsung Galaxy keynote (vague pending announcement)."
+}

--- a/eval/golden/2026-03-04.json
+++ b/eval/golden/2026-03-04.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-04",
+  "baseline_composite": 3.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:17+00:00",
+  "baseline_axes": {
+    "factuality": 2,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "No sources cited anywhere (hard cap: factuality \u2264 2). Pentagon/Anthropic designation, DeepSeek V4, Samsung Gemini recycled from prior 7 days; novel additions (Meta\u2013News Corp deal, NY/Florida AI legislation) partially offset repetition."
+}

--- a/eval/golden/2026-03-05.json
+++ b/eval/golden/2026-03-05.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-05",
+  "baseline_composite": 3.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:41+00:00",
+  "baseline_axes": {
+    "factuality": 2,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "No sources cited anywhere\u2014hard cap applied. Claims align with prior headlines (Anthropic ban, DeepSeek delays, Qwen 3.5) but lack URLs or attribution for benchmarks (83% GDPval, 75% OSWorld-V), policy targets ($1.4T by 2030), or dates. GPT-5.4 launch and Anthropic lawsuit filing are new, but Qwen 3.5 and DeepSeek V4 delays are repeats from Feb 27\u2013Mar 4 coverage."
+}

--- a/eval/golden/2026-03-06.json
+++ b/eval/golden/2026-03-06.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-06",
+  "baseline_composite": 3.7,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:49:09+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 4,
+    "source_diversity": 3,
+    "signal_density": 4,
+    "coherence": 3
+  },
+  "notes": "Sources concentrated in tech and government; 'Block employees publicly stated' is sole independent voice. Quick Hits section (5 disparate items) fragments narrative and dilutes focus from core stories."
+}

--- a/eval/golden/2026-03-07.json
+++ b/eval/golden/2026-03-07.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-07",
+  "baseline_composite": 2.9,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:48:49+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 2,
+    "source_diversity": 1,
+    "signal_density": 5,
+    "coherence": 3
+  },
+  "notes": "Only TechCrunch explicitly cited; top stories (Claude #1, #QuitGPT surge, Oracle/Block layoffs, Samsung Gemini) already in prior-week headlines. New items (Google `gws` CLI, Anthropic lawsuit filings, Pro-Human declaration mainstream coverage) lack visible attribution."
+}

--- a/eval/golden/2026-03-08.json
+++ b/eval/golden/2026-03-08.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-08",
+  "baseline_composite": 3.0,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:49:56+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 3,
+    "source_diversity": 3,
+    "signal_density": 3,
+    "coherence": 3
+  },
+  "notes": "DeepSeek V4 (longest story) offers no concrete outcome \u2014 specs are explicitly unverified, launch is absent, echoing prior week's delay narrative. Signal is strong in featured stories (MacBook Neo specs, Pentagon analysis) but dragged down by speculative Quick Hits and What to Watch."
+}

--- a/eval/golden/2026-03-09.json
+++ b/eval/golden/2026-03-09.json
@@ -1,0 +1,7 @@
+{
+  "card_date": "2026-03-09",
+  "baseline_composite": 4.2,
+  "baseline_judge": "stub-v1",
+  "baseline_prompt_version": "v1",
+  "notes": "Seed baseline from initial stub backfill on 2026-05-13."
+}

--- a/eval/golden/2026-03-09.json
+++ b/eval/golden/2026-03-09.json
@@ -1,7 +1,15 @@
 {
   "card_date": "2026-03-09",
-  "baseline_composite": 4.2,
-  "baseline_judge": "stub-v1",
+  "baseline_composite": 3.85,
+  "baseline_judge": "claude-haiku-4-5-20251001",
   "baseline_prompt_version": "v1",
-  "notes": "Seed baseline from initial stub backfill on 2026-05-13."
+  "baseline_ran_at": "2026-05-14T02:49:15+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 4,
+    "source_diversity": 3,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "Six sources listed for twelve stories with no in-text attribution \u2014 source mapping opaque. Signal-dense on numbers/names (11K vulns, 97M MCP downloads, bill votes) but 'MiniMax praised for rivaling' and 'seven contenders' lack specifics. Excellent topical grouping but no coherent narrative arc tying themes together."
 }

--- a/eval/golden/2026-03-10.json
+++ b/eval/golden/2026-03-10.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-10",
+  "baseline_composite": 3.55,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:49:43+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 4,
+    "source_diversity": 3,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "Multiple concrete claims lack attribution: GPT-5.2 benchmarks, Cursor's 1M-user milestone, Coral Dev Board, and all three regulatory items presented without sources. 7 sources cited for 23 stories\u2014good primary/secondary mix where cited, but ~60% of claims orphaned."
+}

--- a/eval/golden/2026-03-11.json
+++ b/eval/golden/2026-03-11.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-11",
+  "baseline_composite": 3.25,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:50:03+00:00",
+  "baseline_axes": {
+    "factuality": 2,
+    "novelty": 4,
+    "source_diversity": 3,
+    "signal_density": 4,
+    "coherence": 4
+  },
+  "notes": "Sourcing gap: 75% of stories (outage, DryRun, NVIDIA, OpenRouter, World Labs, Replit, FTC, Washington HB 2225) lack any attribution. Seven sources provided but cover only ~5 stories; inline mapping missing. Novelty strong (78% new vs. prior 7 days) but some thematic repeats (Pentagon, DeepSeek V4, regulation)."
+}

--- a/eval/golden/2026-03-12.json
+++ b/eval/golden/2026-03-12.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-12",
+  "baseline_composite": 4.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:50:32+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 4,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 4
+  },
+  "notes": "Novelty includes carryover from Mar 10\u201311: Copilot Cowork, Claude outage. Coherence organized by topic but lacks thematic synthesis connecting related stories like agentic AI launches (Hermes, NemoClaw, Alibaba Page Agent)."
+}

--- a/eval/golden/2026-03-13.json
+++ b/eval/golden/2026-03-13.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-13",
+  "baseline_composite": 3.65,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:50:14+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 4,
+    "coherence": 3
+  },
+  "notes": "NVIDIA Nemotron 3 Super was already covered Mar 10; recycling it as lead story weakens novelty. Header claims 10 stories but contains 14 items. While thematically organized (NVIDIA, xAI, Industry, Policy, Open Source, Research), no explicit synthesis or takeaway ties themes together."
+}

--- a/eval/golden/2026-03-14.json
+++ b/eval/golden/2026-03-14.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-14",
+  "baseline_composite": 4.05,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:50:44+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 4,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 3
+  },
+  "notes": "Briefing is organized by company/topic but lacks synthesis or takeaways. Meta's 20% layoff ($600B infra context), Stanford's entry-level hiring cuts, and BlackRock's bankruptcy prediction could synthesize into a labor-disruption narrative, but each remains isolated. ~40% overlap with prior-week headlines (Nscale, robotics funding, AMI Labs, Pentagon lawsuit all previously covered)."
+}

--- a/eval/golden/2026-03-15.json
+++ b/eval/golden/2026-03-15.json
@@ -1,0 +1,7 @@
+{
+  "card_date": "2026-03-15",
+  "baseline_composite": 4.2,
+  "baseline_judge": "stub-v1",
+  "baseline_prompt_version": "v1",
+  "notes": "Seed baseline from initial stub backfill on 2026-05-13."
+}

--- a/eval/golden/2026-03-15.json
+++ b/eval/golden/2026-03-15.json
@@ -1,7 +1,15 @@
 {
   "card_date": "2026-03-15",
-  "baseline_composite": 4.2,
-  "baseline_judge": "stub-v1",
+  "baseline_composite": 3.0,
+  "baseline_judge": "claude-haiku-4-5-20251001",
   "baseline_prompt_version": "v1",
-  "notes": "Seed baseline from initial stub backfill on 2026-05-13."
+  "baseline_ran_at": "2026-05-14T02:51:00+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 2,
+    "source_diversity": 3,
+    "signal_density": 4,
+    "coherence": 3
+  },
+  "notes": "Weak novelty: ~50% rehash of prior 7 days (Pentagon dispute, GPT-5.1 retirement, Windsurf Wave 13, AAIF/MCP 10K servers, Meta 20% cuts, Gemini Embedding 2, Nscale $2B). Only ~40% new (GigaTIME, Copilot Health, Granite 4.0, Vercel SDK 6, Next.js 16, policy statements). No synthesis or takeaways within sections."
 }

--- a/eval/golden/2026-03-16.json
+++ b/eval/golden/2026-03-16.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-16",
+  "baseline_composite": 4.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:51:00+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 4,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 4
+  },
+  "notes": "Thematically organized but lacks synthesis or takeaway. Vera Rubin and Groq 3 LPU were previewed in prior coverage; briefing confirms details but doesn't advance narrative."
+}

--- a/eval/golden/2026-03-17.json
+++ b/eval/golden/2026-03-17.json
@@ -1,0 +1,15 @@
+{
+  "card_date": "2026-03-17",
+  "baseline_composite": 4.2,
+  "baseline_judge": "claude-haiku-4-5-20251001",
+  "baseline_prompt_version": "v1",
+  "baseline_ran_at": "2026-05-14T02:51:14+00:00",
+  "baseline_axes": {
+    "factuality": 3,
+    "novelty": 4,
+    "source_diversity": 5,
+    "signal_density": 5,
+    "coherence": 5
+  },
+  "notes": "Sources cited but not granularly mapped to claims. Unsourced specifics: '~250 users affected' (Claude outage), '1,016 Blackwell Ultra GPUs, 9,000+ petaflops' (Eli Lilly). Robotics mega-round (Mind, Rhoda, Sunday, Oxa) repeats prior week reporting."
+}

--- a/eval/golden/2026-03-18.json
+++ b/eval/golden/2026-03-18.json
@@ -1,0 +1,7 @@
+{
+  "card_date": "2026-03-18",
+  "baseline_composite": 4.2,
+  "baseline_judge": "stub-v1",
+  "baseline_prompt_version": "v1",
+  "notes": "Seed baseline from initial stub backfill on 2026-05-13. Replace baseline_composite + baseline_judge when re-baselining against the real Claude judge."
+}

--- a/eval/golden/2026-03-18.json
+++ b/eval/golden/2026-03-18.json
@@ -1,7 +1,15 @@
 {
   "card_date": "2026-03-18",
-  "baseline_composite": 4.2,
-  "baseline_judge": "stub-v1",
+  "baseline_composite": 4.0,
+  "baseline_judge": "claude-haiku-4-5-20251001",
   "baseline_prompt_version": "v1",
-  "notes": "Seed baseline from initial stub backfill on 2026-05-13. Replace baseline_composite + baseline_judge when re-baselining against the real Claude judge."
+  "baseline_ran_at": "2026-05-14T02:51:27+00:00",
+  "baseline_axes": {
+    "factuality": 4,
+    "novelty": 3,
+    "source_diversity": 4,
+    "signal_density": 5,
+    "coherence": 4
+  },
+  "notes": "Novelty drags from GPT-5.4 mini pricing (prior headlines show arrival days before) and UK copyright report (expected delivery on Mar 18, not novel). TADA TTS and SAFECHAT Act are new; fourth Claude outage also new. Strong sourcing and concrete numbers throughout."
 }

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -65,14 +66,46 @@ def parse_judge_response(text: str) -> dict:
 # --- Backends -----------------------------------------------------------------
 
 
-def _run_cli(cmd: list[str], stdin: str, timeout: int = 120) -> str:
-    proc = subprocess.run(
-        cmd,
-        input=stdin,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+
+
+def _log_call(cmd: list[str], stdin: str, stdout: str, stderr: str, rc: int, elapsed: float) -> None:
+    """Append a per-call trace to logs/eval-judge-YYYY-MM-DD.log."""
+    try:
+        LOG_DIR.mkdir(exist_ok=True)
+        import datetime as _dt
+        day = _dt.date.today().isoformat()
+        log_path = LOG_DIR / f"eval-judge-{day}.log"
+        with log_path.open("a") as f:
+            f.write(f"--- {_dt.datetime.now().isoformat(timespec='seconds')} "
+                    f"rc={rc} elapsed={elapsed:.1f}s ---\n")
+            f.write(f"CMD: {' '.join(cmd)}\n")
+            if stdin:
+                f.write(f"STDIN[:200]: {stdin[:200]}\n")
+            f.write(f"STDOUT[:2000]:\n{stdout[:2000]}\n")
+            if stderr:
+                f.write(f"STDERR[:800]:\n{stderr[:800]}\n")
+            f.write("\n")
+    except Exception:
+        pass  # logging must never break a run
+
+
+def _run_cli(cmd: list[str], stdin: str, timeout: int = 240) -> str:
+    # Match briefing.sh: clear CLAUDECODE so the judge CLI does not refuse to
+    # launch when invoked from inside an existing Claude Code session.
+    env = {k: v for k, v in os.environ.items() if k not in ("CLAUDECODE", "CLAUDE_CODE")}
+    import time as _time
+    t0 = _time.monotonic()
+    try:
+        proc = subprocess.run(
+            cmd, input=stdin, capture_output=True, text=True,
+            timeout=timeout, env=env,
+        )
+    except subprocess.TimeoutExpired as e:
+        _log_call(cmd, stdin, e.stdout or "", e.stderr or "", -1, _time.monotonic() - t0)
+        raise RuntimeError(f"Judge CLI timed out after {timeout}s") from e
+    elapsed = _time.monotonic() - t0
+    _log_call(cmd, stdin, proc.stdout, proc.stderr, proc.returncode, elapsed)
     if proc.returncode != 0:
         raise RuntimeError(
             f"Judge CLI failed (rc={proc.returncode}): {proc.stderr.strip()[:400]}"
@@ -107,7 +140,11 @@ def _backend_claude_cli(prompt: str) -> tuple[dict, str, str]:
     if not (claude and os.path.exists(claude)):
         raise RuntimeError("claude CLI not found; install or use --judge stub")
     model = os.environ.get("EVAL_JUDGE_MODEL", "claude-haiku-4-5-20251001")
-    raw = _run_cli([claude, "-p", "--model", model], prompt)
+    # Match briefing.sh invocation: prompt as positional arg, not stdin.
+    raw = _run_cli(
+        [claude, "-p", "--model", model, "--dangerously-skip-permissions", prompt],
+        "",
+    )
     return parse_judge_response(raw), raw, model
 
 
@@ -115,7 +152,7 @@ def _backend_codex_cli(prompt: str) -> tuple[dict, str, str]:
     codex = shutil.which("codex")
     if not codex:
         raise RuntimeError("codex CLI not found")
-    raw = _run_cli([codex, "exec", "-"], prompt)
+    raw = _run_cli([codex, "exec", "--full-auto", prompt], "")
     return parse_judge_response(raw), raw, "codex-cli"
 
 

--- a/eval/judge.py
+++ b/eval/judge.py
@@ -1,0 +1,143 @@
+"""Judge backends.
+
+The project shells out to AI CLIs (claude / codex / gemini) everywhere else,
+so we match that convention. A ``stub`` backend is provided for tests and CI
+so the harness exercises end-to-end without burning API credits.
+
+Each backend returns ``(scores_dict, raw_response_text, model_id)``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+PROMPT_VERSION = "v1"
+JUDGE_PROMPT_PATH = Path(__file__).resolve().parent / "judge_prompt.md"
+
+
+@dataclass
+class JudgeResult:
+    scores: dict
+    raw: str
+    model: str
+    prompt_version: str
+
+
+def _load_judge_prompt() -> str:
+    return JUDGE_PROMPT_PATH.read_text()
+
+
+def _compose_input(briefing_text: str, prior_headlines: list[str]) -> str:
+    prior = "\n".join(prior_headlines) if prior_headlines else "(none available)"
+    return (
+        f"{_load_judge_prompt()}\n\n"
+        f"---\nBRIEFING:\n{briefing_text}\n\n"
+        f"---\nPRIOR_HEADLINES (last 7 days):\n{prior}\n"
+    )
+
+
+_JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+_BARE_JSON = re.compile(r"(\{[^{}]*\"factuality\"[^{}]*\})", re.DOTALL)
+_REQUIRED = ("factuality", "novelty", "source_diversity", "signal_density", "coherence")
+
+
+def parse_judge_response(text: str) -> dict:
+    m = _JSON_BLOCK.search(text) or _BARE_JSON.search(text)
+    if not m:
+        raise ValueError(f"No JSON object found in judge response:\n{text[:500]}")
+    obj = json.loads(m.group(1))
+    for k in _REQUIRED:
+        if k not in obj:
+            raise ValueError(f"Judge response missing key: {k}")
+        v = obj[k]
+        if not (isinstance(v, int) and 1 <= v <= 5):
+            raise ValueError(f"Axis {k} out of range or non-int: {v!r}")
+    obj.setdefault("notes", "")
+    return obj
+
+
+# --- Backends -----------------------------------------------------------------
+
+
+def _run_cli(cmd: list[str], stdin: str, timeout: int = 120) -> str:
+    proc = subprocess.run(
+        cmd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Judge CLI failed (rc={proc.returncode}): {proc.stderr.strip()[:400]}"
+        )
+    return proc.stdout
+
+
+def _backend_stub(prompt: str) -> tuple[dict, str, str]:
+    """Deterministic stub: scores reflect simple heuristics on the prompt."""
+    has_url = "http" in prompt.lower()
+    has_numbers = bool(re.search(r"\$\d|\d+%|\d{2,}", prompt))
+    bullet_count = prompt.count("\n- ")
+    factuality = 4 if has_url else 2
+    novelty = 4
+    diversity = 4 if prompt.count("http") >= 5 else 3
+    density = 5 if has_numbers and bullet_count >= 8 else 3
+    coherence = 4 if "**" in prompt else 3
+    scores = {
+        "factuality": factuality,
+        "novelty": novelty,
+        "source_diversity": diversity,
+        "signal_density": density,
+        "coherence": coherence,
+        "notes": "stub judge: heuristics over URL/number/bullet/bold presence",
+    }
+    raw = "```json\n" + json.dumps(scores, indent=2) + "\n```"
+    return scores, raw, "stub-v1"
+
+
+def _backend_claude_cli(prompt: str) -> tuple[dict, str, str]:
+    claude = shutil.which("claude") or os.path.expanduser("~/.local/bin/claude")
+    if not (claude and os.path.exists(claude)):
+        raise RuntimeError("claude CLI not found; install or use --judge stub")
+    model = os.environ.get("EVAL_JUDGE_MODEL", "claude-haiku-4-5-20251001")
+    raw = _run_cli([claude, "-p", "--model", model], prompt)
+    return parse_judge_response(raw), raw, model
+
+
+def _backend_codex_cli(prompt: str) -> tuple[dict, str, str]:
+    codex = shutil.which("codex")
+    if not codex:
+        raise RuntimeError("codex CLI not found")
+    raw = _run_cli([codex, "exec", "-"], prompt)
+    return parse_judge_response(raw), raw, "codex-cli"
+
+
+def _backend_gemini_cli(prompt: str) -> tuple[dict, str, str]:
+    gemini = shutil.which("gemini")
+    if not gemini:
+        raise RuntimeError("gemini CLI not found")
+    raw = _run_cli([gemini, "-p", prompt], "")
+    return parse_judge_response(raw), raw, "gemini-cli"
+
+
+BACKENDS = {
+    "stub": _backend_stub,
+    "claude": _backend_claude_cli,
+    "codex": _backend_codex_cli,
+    "gemini": _backend_gemini_cli,
+}
+
+
+def judge(briefing_text: str, prior_headlines: list[str], backend: str = "stub") -> JudgeResult:
+    if backend not in BACKENDS:
+        raise ValueError(f"Unknown backend {backend!r}. Choose from {list(BACKENDS)}")
+    prompt = _compose_input(briefing_text, prior_headlines)
+    scores, raw, model = BACKENDS[backend](prompt)
+    return JudgeResult(scores=scores, raw=raw, model=model, prompt_version=PROMPT_VERSION)

--- a/eval/judge_prompt.md
+++ b/eval/judge_prompt.md
@@ -1,0 +1,40 @@
+# Judge Prompt v1
+
+You are a strict editorial reviewer scoring an AI news briefing on a fixed rubric.
+
+## Rubric
+
+Score each axis as an **integer 1–5**. Definitions:
+
+- **factuality** (1=unverifiable claims, 5=every concrete claim is sourced)
+- **novelty** (1=rehashed from prior week, 5=all new vs. prior 7 days)
+- **source_diversity** (1=single dominant domain, 5=5+ distinct domains, primary+secondary mix)
+- **signal_density** (1=hype words only, 5=concrete numbers/names/outcomes per item)
+- **coherence** (1=bullet soup, 5=thematic grouping with takeaways)
+
+Hard caps:
+- No sources cited anywhere → factuality ≤ 2
+- Story headings present but empty bodies → signal_density ≤ 2
+
+## Input
+
+You will receive:
+1. `BRIEFING` — the briefing text for the target date
+2. `PRIOR_HEADLINES` — the headlines of cards from the previous 7 days (may be empty)
+
+## Output
+
+Return **only** a single JSON object in a fenced ```json block. No prose outside the block.
+
+```json
+{
+  "factuality": 1-5,
+  "novelty": 1-5,
+  "source_diversity": 1-5,
+  "signal_density": 1-5,
+  "coherence": 1-5,
+  "notes": "1-3 sentences citing the strongest evidence for the lowest score"
+}
+```
+
+Be terse in `notes`. Cite specific items from the briefing when justifying a low score.

--- a/eval/report.py
+++ b/eval/report.py
@@ -1,0 +1,99 @@
+"""Weekly Markdown report of eval scores.
+
+    python eval/report.py --as-of 2026-03-18 --window 7
+
+Prints Markdown to stdout. Pipe into Notion/Teams/Slack via the project's
+existing publish scripts, or commit it under ``logs/eval-reports/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from store import fetch_runs  # noqa: E402
+
+AXES = ("factuality", "novelty", "source_diversity", "signal_density", "coherence")
+
+
+def build(as_of: str, window: int = 7) -> str:
+    y, m, d = (int(x) for x in as_of.split("-"))
+    end = date(y, m, d)
+    start = end - timedelta(days=window - 1)
+    rows = fetch_runs(since=start.isoformat(), until=end.isoformat())
+
+    # Latest run per date.
+    by_date: dict[str, dict] = {}
+    for r in rows:
+        d = r["card_date"]
+        if d not in by_date or r["ran_at"] > by_date[d]["ran_at"]:
+            by_date[d] = r
+
+    lines: list[str] = []
+    lines.append(f"# Briefing Eval Report — {start.isoformat()} → {end.isoformat()}")
+    lines.append("")
+    if not by_date:
+        lines.append("_No eval data in window._")
+        return "\n".join(lines)
+
+    composites = [r["composite"] for r in by_date.values()]
+    lines.append(f"**Coverage:** {len(by_date)}/{window} days")
+    lines.append(f"**Composite (median):** {statistics.median(composites):.2f}")
+    lines.append(f"**Composite (min/max):** {min(composites):.2f} / {max(composites):.2f}")
+    lines.append("")
+
+    lines.append("## Axis medians")
+    lines.append("")
+    lines.append("| axis | median |")
+    lines.append("| --- | ---: |")
+    for axis in AXES:
+        med = statistics.median(r[axis] for r in by_date.values())
+        lines.append(f"| {axis} | {med:.1f} |")
+    lines.append("")
+
+    lines.append("## Per-day detail")
+    lines.append("")
+    cols = ["date", "composite", *AXES, "judge", "notes"]
+    lines.append("| " + " | ".join(cols) + " |")
+    lines.append("|" + "|".join(["---"] * len(cols)) + "|")
+    for d in sorted(by_date):
+        r = by_date[d]
+        notes = (r.get("notes") or "").replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    d,
+                    f"{r['composite']:.2f}",
+                    *[str(r[a]) for a in AXES],
+                    r["judge_model"],
+                    notes[:80],
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--as-of", required=True, help="YYYY-MM-DD")
+    p.add_argument("--window", type=int, default=7)
+    p.add_argument("--out", help="Write to file (otherwise stdout)")
+    args = p.parse_args(argv)
+    md = build(args.as_of, args.window)
+    if args.out:
+        Path(args.out).write_text(md)
+        print(f"wrote {args.out}")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/rubric.md
+++ b/eval/rubric.md
@@ -1,0 +1,26 @@
+# Briefing Quality Rubric (v1)
+
+Five axes, each scored **1–5 integer**. Composite = weighted mean (weights below).
+
+| Axis            | Weight | 1 (bad)                                  | 5 (excellent)                                                    |
+| --------------- | -----: | ---------------------------------------- | ---------------------------------------------------------------- |
+| factuality      |   0.30 | Unverifiable claims, no sources cited    | Every concrete claim (number/name/date) maps to a cited source   |
+| novelty         |   0.20 | Stories already covered in last 7 days   | All stories new vs. prior 7-day window; no rehash                |
+| source_diversity|   0.15 | One or two domains dominate              | 5+ distinct domains; mix of primary (filings, blogs) + secondary |
+| signal_density  |   0.20 | Vague hype words, no numbers             | Concrete numbers, named entities, specific outcomes per item     |
+| coherence       |   0.15 | Bullet soup, no narrative                | Items grouped by theme with a clear takeaway per topic           |
+
+**Composite** = round( 0.30·F + 0.20·N + 0.15·D + 0.20·S + 0.15·C , 2 )
+
+## Pass thresholds
+
+- **publish gate**: composite ≥ 3.0 AND no axis < 2
+- **regression gate** (golden set): per-card composite drop ≤ 0.5 vs. baseline
+- **drift alert**: rolling-7d median composite > 1.5 stddev below trailing-30d median for 2 consecutive days
+
+## Scoring rules
+
+- Score the briefing **as published** — do not credit information not present in the card.
+- If sources are absent, factuality caps at 2.
+- Stories listed but with empty body cap signal_density at 2.
+- Novelty is scored against the **prior 7 calendar days** of cards in `example-cards/` when available; otherwise score on intrinsic recency cues in the text.

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -51,7 +51,13 @@ def _score_one(card_date: str, backend: str) -> dict:
 
 
 def cmd_score(args: argparse.Namespace) -> int:
+    import time
+    print(f"[{time.strftime('%H:%M:%S')}] judging {args.date} via {args.judge!r}... "
+          f"(tail -f logs/eval-judge-{time.strftime('%Y-%m-%d')}.log for progress)",
+          flush=True, file=sys.stderr)
+    t0 = time.monotonic()
     out = _score_one(args.date, args.judge)
+    out["elapsed_seconds"] = round(time.monotonic() - t0, 1)
     print(json.dumps(out, indent=2))
     if args.gate and out["composite"] < args.gate_threshold:
         print(f"GATE FAIL: composite {out['composite']} < {args.gate_threshold}", file=sys.stderr)
@@ -60,6 +66,9 @@ def cmd_score(args: argparse.Namespace) -> int:
 
 
 def cmd_backfill(args: argparse.Namespace) -> int:
+    import time
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     card_dir = CARD_DIR_DEFAULT
     cards = sorted(p.name[:10] for p in card_dir.glob("*-card.json"))
     if not cards:
@@ -72,16 +81,47 @@ def cmd_backfill(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"Backfilling {len(cards)} cards with backend={args.judge!r} ...")
+
+    workers = max(1, args.workers)
+    if args.judge == "stub":
+        workers = 1  # stub is instant; serial keeps output ordered
+    log_hint = f"logs/eval-judge-{time.strftime('%Y-%m-%d')}.log"
+    print(
+        f"Backfilling {len(cards)} cards | backend={args.judge!r} | workers={workers}",
+        flush=True,
+    )
+    print(f"Per-call trace: tail -f {log_hint}", flush=True)
+    t0 = time.monotonic()
     failures = 0
-    for d in cards:
-        try:
-            r = _score_one(d, args.judge)
-            print(f"  {d}: composite={r['composite']}")
-        except Exception as e:  # keep going through the set
-            failures += 1
-            print(f"  {d}: ERROR {e}", file=sys.stderr)
-    print(f"Done. {len(cards) - failures}/{len(cards)} succeeded.")
+
+    def _job(d: str):
+        ts = time.strftime("%H:%M:%S")
+        print(f"  [{ts}] {d}: judging...", flush=True)
+        return d, _score_one(d, args.judge)
+
+    if workers == 1:
+        for d in cards:
+            try:
+                _, r = _job(d)
+                print(f"  {d}: composite={r['composite']}", flush=True)
+            except Exception as e:
+                failures += 1
+                print(f"  {d}: ERROR {e}", file=sys.stderr, flush=True)
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(_job, d): d for d in cards}
+            for fut in as_completed(futures):
+                d = futures[fut]
+                try:
+                    _, r = fut.result()
+                    print(f"  {d}: composite={r['composite']}", flush=True)
+                except Exception as e:
+                    failures += 1
+                    print(f"  {d}: ERROR {e}", file=sys.stderr, flush=True)
+
+    dt = time.monotonic() - t0
+    print(f"Done. {len(cards) - failures}/{len(cards)} succeeded in {dt:.1f}s "
+          f"({dt / max(len(cards), 1):.1f}s/card).")
     return 0 if failures == 0 else 1
 
 
@@ -153,6 +193,8 @@ def main(argv: list[str] | None = None) -> int:
 
     bp = sub.add_parser("backfill", parents=[common], help="Score every card in example-cards/")
     bp.add_argument("--max-calls", type=int, default=MAX_JUDGE_CALLS_DEFAULT)
+    bp.add_argument("--workers", type=int, default=4,
+                    help="Concurrent judge calls (real backends only; stub forces 1)")
     bp.set_defaults(func=cmd_backfill)
 
     rp = sub.add_parser("regression", parents=[common], help="Re-judge golden set, fail on drift")

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -1,0 +1,174 @@
+"""CLI entry point: judge a single briefing card and persist the score.
+
+Examples
+--------
+    python eval/runner.py --date 2026-03-18 --judge stub
+    python eval/runner.py --date 2026-03-18 --judge claude
+    python eval/runner.py --backfill --judge stub
+    python eval/runner.py --regression --judge claude
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow `python eval/runner.py` from repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from extract import find_card, load_card, prior_headlines, CARD_DIR_DEFAULT  # noqa: E402
+from judge import PROMPT_VERSION, judge  # noqa: E402
+from store import composite, upsert_run, fetch_runs  # noqa: E402
+
+GOLDEN_DIR = Path(__file__).resolve().parent / "golden"
+MAX_JUDGE_CALLS_DEFAULT = 50
+
+
+def _score_one(card_date: str, backend: str) -> dict:
+    path = find_card(card_date)
+    b = load_card(path)
+    prior = prior_headlines(card_date)
+    result = judge(b.body_text, prior, backend=backend)
+    comp = upsert_run(
+        card_date=card_date,
+        prompt_version=result.prompt_version,
+        judge_model=result.model,
+        scores=result.scores,
+        raw=result.raw,
+    )
+    return {
+        "card_date": card_date,
+        "judge_model": result.model,
+        "prompt_version": result.prompt_version,
+        "composite": comp,
+        **{k: result.scores[k] for k in (
+            "factuality", "novelty", "source_diversity", "signal_density", "coherence",
+        )},
+        "notes": result.scores.get("notes", ""),
+    }
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    out = _score_one(args.date, args.judge)
+    print(json.dumps(out, indent=2))
+    if args.gate and out["composite"] < args.gate_threshold:
+        print(f"GATE FAIL: composite {out['composite']} < {args.gate_threshold}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def cmd_backfill(args: argparse.Namespace) -> int:
+    card_dir = CARD_DIR_DEFAULT
+    cards = sorted(p.name[:10] for p in card_dir.glob("*-card.json"))
+    if not cards:
+        print(f"No cards found in {card_dir}", file=sys.stderr)
+        return 1
+    if len(cards) > args.max_calls:
+        print(
+            f"Refusing to judge {len(cards)} cards (--max-calls={args.max_calls}). "
+            "Bump --max-calls if intentional.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Backfilling {len(cards)} cards with backend={args.judge!r} ...")
+    failures = 0
+    for d in cards:
+        try:
+            r = _score_one(d, args.judge)
+            print(f"  {d}: composite={r['composite']}")
+        except Exception as e:  # keep going through the set
+            failures += 1
+            print(f"  {d}: ERROR {e}", file=sys.stderr)
+    print(f"Done. {len(cards) - failures}/{len(cards)} succeeded.")
+    return 0 if failures == 0 else 1
+
+
+def cmd_regression(args: argparse.Namespace) -> int:
+    """Re-judge each card in golden/ and compare to its baseline composite.
+
+    Each golden card is a JSON file:
+        {"card_date": "2026-03-04", "baseline_composite": 4.3}
+    """
+    golden_files = sorted(GOLDEN_DIR.glob("*.json"))
+    if not golden_files:
+        print(f"No golden cards in {GOLDEN_DIR}. Add some first.", file=sys.stderr)
+        return 1
+    threshold = args.regression_drop
+    failures: list[str] = []
+    for gf in golden_files:
+        spec = json.loads(gf.read_text())
+        d = spec["card_date"]
+        baseline = float(spec["baseline_composite"])
+        try:
+            r = _score_one(d, args.judge)
+        except Exception as e:
+            failures.append(f"{d}: judge error {e}")
+            continue
+        delta = r["composite"] - baseline
+        verdict = "OK"
+        if delta < -threshold:
+            verdict = "REGRESSED"
+            failures.append(f"{d}: composite {r['composite']} (baseline {baseline}, Δ {delta:+.2f})")
+        print(f"  {d}: composite={r['composite']} baseline={baseline} Δ={delta:+.2f} {verdict}")
+    if failures:
+        print(f"\nFAIL: {len(failures)} regression(s)", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 2
+    print(f"\nOK: {len(golden_files)} golden cards within Δ ≤ {threshold:.2f}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    rows = fetch_runs(since=args.since, until=args.until)
+    if args.format == "json":
+        print(json.dumps(rows, indent=2))
+    else:
+        if not rows:
+            print("(no rows)")
+            return 0
+        cols = ("card_date", "judge_model", "composite",
+                "factuality", "novelty", "source_diversity",
+                "signal_density", "coherence")
+        print("\t".join(cols))
+        for r in rows:
+            print("\t".join(str(r[c]) for c in cols))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Briefing eval runner")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--judge", default="stub", choices=["stub", "claude", "codex", "gemini"])
+
+    sp = sub.add_parser("score", parents=[common], help="Score one briefing")
+    sp.add_argument("--date", required=True, help="YYYY-MM-DD card date")
+    sp.add_argument("--gate", action="store_true", help="Exit non-zero if below threshold")
+    sp.add_argument("--gate-threshold", type=float, default=3.0)
+    sp.set_defaults(func=cmd_score)
+
+    bp = sub.add_parser("backfill", parents=[common], help="Score every card in example-cards/")
+    bp.add_argument("--max-calls", type=int, default=MAX_JUDGE_CALLS_DEFAULT)
+    bp.set_defaults(func=cmd_backfill)
+
+    rp = sub.add_parser("regression", parents=[common], help="Re-judge golden set, fail on drift")
+    rp.add_argument("--regression-drop", type=float, default=0.5,
+                    help="Allowed composite drop vs. golden baseline")
+    rp.set_defaults(func=cmd_regression)
+
+    shp = sub.add_parser("show", help="Dump eval rows")
+    shp.add_argument("--since")
+    shp.add_argument("--until")
+    shp.add_argument("--format", choices=["tsv", "json"], default="tsv")
+    shp.set_defaults(func=cmd_show)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/schema.sql
+++ b/eval/schema.sql
@@ -1,0 +1,21 @@
+-- Briefing eval store schema v1
+-- Idempotent on (card_date, prompt_version, judge_model): re-runs overwrite.
+
+CREATE TABLE IF NOT EXISTS eval_runs (
+    card_date        TEXT NOT NULL,        -- YYYY-MM-DD of the briefing card
+    prompt_version   TEXT NOT NULL,        -- judge prompt version, e.g. "v1"
+    judge_model      TEXT NOT NULL,        -- e.g. "claude-haiku-4-5-20251001"
+    ran_at           TEXT NOT NULL,        -- ISO-8601 UTC timestamp
+    factuality       INTEGER NOT NULL CHECK (factuality       BETWEEN 1 AND 5),
+    novelty          INTEGER NOT NULL CHECK (novelty          BETWEEN 1 AND 5),
+    source_diversity INTEGER NOT NULL CHECK (source_diversity BETWEEN 1 AND 5),
+    signal_density   INTEGER NOT NULL CHECK (signal_density   BETWEEN 1 AND 5),
+    coherence        INTEGER NOT NULL CHECK (coherence        BETWEEN 1 AND 5),
+    composite        REAL    NOT NULL,
+    notes            TEXT,
+    judge_raw        TEXT,                 -- raw judge response for debug
+    PRIMARY KEY (card_date, prompt_version, judge_model)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eval_runs_date ON eval_runs (card_date);
+CREATE INDEX IF NOT EXISTS idx_eval_runs_ran_at ON eval_runs (ran_at);

--- a/eval/seed_golden.py
+++ b/eval/seed_golden.py
@@ -1,0 +1,100 @@
+"""Seed eval/golden/ from the current contents of eval/store.sqlite.
+
+After backfilling against a real judge (e.g. ``make eval-backfill JUDGE=claude``),
+run this to lift every persisted score into a pinned baseline. The regression
+gate (``make eval-regression``) will then fail when any card's composite drops
+more than ``--regression-drop`` points below the seeded baseline.
+
+Usage:
+    python3 eval/seed_golden.py                                 # use latest run per date
+    python3 eval/seed_golden.py --judge claude-haiku-4-5-20251001
+    python3 eval/seed_golden.py --since 2026-03-01 --until 2026-03-18
+    python3 eval/seed_golden.py --dry-run
+
+The script is idempotent. Existing golden files for the same date are
+overwritten so the on-disk baseline always matches the most recent intentional
+re-baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from store import fetch_runs  # noqa: E402
+
+GOLDEN_DIR = Path(__file__).resolve().parent / "golden"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Seed eval/golden/ from store.sqlite")
+    p.add_argument("--judge", help="Only seed from this judge_model")
+    p.add_argument("--prompt-version", help="Only seed from this prompt_version")
+    p.add_argument("--since", help="YYYY-MM-DD lower bound on card_date")
+    p.add_argument("--until", help="YYYY-MM-DD upper bound on card_date")
+    p.add_argument("--dry-run", action="store_true", help="Print what would change without writing")
+    p.add_argument("--clean", action="store_true",
+                   help="Delete existing golden files before writing (full rebase)")
+    args = p.parse_args(argv)
+
+    rows = fetch_runs(
+        since=args.since,
+        until=args.until,
+        prompt_version=args.prompt_version,
+        judge_model=args.judge,
+    )
+    if not rows:
+        print("No matching rows in eval_runs. Run `make eval-backfill JUDGE=claude` first.",
+              file=sys.stderr)
+        return 1
+
+    # Latest ran_at per (card_date) wins.
+    latest: dict[str, dict] = {}
+    for r in rows:
+        d = r["card_date"]
+        if d not in latest or r["ran_at"] > latest[d]["ran_at"]:
+            latest[d] = r
+
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    if args.clean and not args.dry_run:
+        for f in GOLDEN_DIR.glob("*.json"):
+            f.unlink()
+        print(f"cleaned {GOLDEN_DIR}")
+
+    written = 0
+    for d in sorted(latest):
+        r = latest[d]
+        spec = {
+            "card_date": r["card_date"],
+            "baseline_composite": r["composite"],
+            "baseline_judge": r["judge_model"],
+            "baseline_prompt_version": r["prompt_version"],
+            "baseline_ran_at": r["ran_at"],
+            "baseline_axes": {
+                "factuality": r["factuality"],
+                "novelty": r["novelty"],
+                "source_diversity": r["source_diversity"],
+                "signal_density": r["signal_density"],
+                "coherence": r["coherence"],
+            },
+            "notes": (r.get("notes") or "").strip(),
+        }
+        out = GOLDEN_DIR / f"{d}.json"
+        if args.dry_run:
+            print(f"  would write {out} composite={r['composite']} judge={r['judge_model']}")
+        else:
+            out.write_text(json.dumps(spec, indent=2) + "\n")
+            print(f"  wrote {out} composite={r['composite']} judge={r['judge_model']}")
+            written += 1
+    if args.dry_run:
+        print(f"dry-run: {len(latest)} cards would be written")
+    else:
+        print(f"seeded {written} golden cards into {GOLDEN_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/store.py
+++ b/eval/store.py
@@ -1,0 +1,117 @@
+"""SQLite-backed store for eval runs."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+DB_PATH_DEFAULT = Path(__file__).resolve().parent / "store.sqlite"
+SCHEMA_PATH = Path(__file__).resolve().parent / "schema.sql"
+
+WEIGHTS = {
+    "factuality": 0.30,
+    "novelty": 0.20,
+    "source_diversity": 0.15,
+    "signal_density": 0.20,
+    "coherence": 0.15,
+}
+
+
+def composite(scores: dict) -> float:
+    total = sum(WEIGHTS[k] * scores[k] for k in WEIGHTS)
+    return round(total, 2)
+
+
+@contextmanager
+def connect(db_path: Path | None = None):
+    p = db_path or DB_PATH_DEFAULT
+    conn = sqlite3.connect(p)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.executescript(SCHEMA_PATH.read_text())
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def upsert_run(
+    *,
+    card_date: str,
+    prompt_version: str,
+    judge_model: str,
+    scores: dict,
+    raw: str,
+    db_path: Path | None = None,
+) -> float:
+    comp = composite(scores)
+    ran_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO eval_runs (
+                card_date, prompt_version, judge_model, ran_at,
+                factuality, novelty, source_diversity, signal_density, coherence,
+                composite, notes, judge_raw
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(card_date, prompt_version, judge_model) DO UPDATE SET
+                ran_at = excluded.ran_at,
+                factuality = excluded.factuality,
+                novelty = excluded.novelty,
+                source_diversity = excluded.source_diversity,
+                signal_density = excluded.signal_density,
+                coherence = excluded.coherence,
+                composite = excluded.composite,
+                notes = excluded.notes,
+                judge_raw = excluded.judge_raw
+            """,
+            (
+                card_date,
+                prompt_version,
+                judge_model,
+                ran_at,
+                scores["factuality"],
+                scores["novelty"],
+                scores["source_diversity"],
+                scores["signal_density"],
+                scores["coherence"],
+                comp,
+                scores.get("notes", ""),
+                raw,
+            ),
+        )
+    return comp
+
+
+def fetch_runs(
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    prompt_version: str | None = None,
+    judge_model: str | None = None,
+    db_path: Path | None = None,
+) -> list[dict]:
+    where: list[str] = []
+    args: list = []
+    if since:
+        where.append("card_date >= ?")
+        args.append(since)
+    if until:
+        where.append("card_date <= ?")
+        args.append(until)
+    if prompt_version:
+        where.append("prompt_version = ?")
+        args.append(prompt_version)
+    if judge_model:
+        where.append("judge_model = ?")
+        args.append(judge_model)
+    sql = "SELECT * FROM eval_runs"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY card_date ASC"
+    with connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = [dict(r) for r in conn.execute(sql, args).fetchall()]
+    return rows

--- a/eval/tests/test_harness.py
+++ b/eval/tests/test_harness.py
@@ -1,0 +1,160 @@
+"""Unit tests for the eval harness.
+
+Uses the stub judge so tests do not require an AI CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+EVAL_DIR = HERE.parent
+sys.path.insert(0, str(EVAL_DIR))
+
+import extract  # noqa: E402
+import judge  # noqa: E402
+import store  # noqa: E402
+import drift  # noqa: E402
+import report  # noqa: E402
+
+
+class ExtractTests(unittest.TestCase):
+    def test_load_card_pulls_headlines_and_urls(self):
+        path = extract.find_card("2026-03-18")
+        b = extract.load_card(path)
+        self.assertEqual(b.card_date, "2026-03-18")
+        self.assertGreater(len(b.headlines), 0)
+        self.assertTrue(any(h.startswith("- ") for h in b.headlines))
+        self.assertGreater(len(b.source_urls), 0)
+        self.assertTrue(all(u.startswith("http") for u in b.source_urls))
+
+    def test_prior_headlines_window(self):
+        prior = extract.prior_headlines("2026-03-18", days=7)
+        # We have continuous cards 2026-03-11..2026-03-17 → 7 days, many headlines.
+        self.assertGreater(len(prior), 10)
+
+
+class JudgeTests(unittest.TestCase):
+    def test_stub_returns_valid_scores(self):
+        path = extract.find_card("2026-03-18")
+        b = extract.load_card(path)
+        result = judge.judge(b.body_text, [], backend="stub")
+        for axis in ("factuality", "novelty", "source_diversity",
+                     "signal_density", "coherence"):
+            self.assertIn(axis, result.scores)
+            v = result.scores[axis]
+            self.assertIsInstance(v, int)
+            self.assertGreaterEqual(v, 1)
+            self.assertLessEqual(v, 5)
+        self.assertEqual(result.prompt_version, "v1")
+
+    def test_parse_judge_response_rejects_garbage(self):
+        with self.assertRaises(ValueError):
+            judge.parse_judge_response("hello world, no JSON here")
+
+    def test_parse_judge_response_rejects_out_of_range(self):
+        bad = '```json\n{"factuality":7,"novelty":3,"source_diversity":3,"signal_density":3,"coherence":3}\n```'
+        with self.assertRaises(ValueError):
+            judge.parse_judge_response(bad)
+
+
+class StoreTests(unittest.TestCase):
+    def _tmp_db(self) -> Path:
+        td = tempfile.mkdtemp(prefix="eval_test_")
+        return Path(td) / "store.sqlite"
+
+    def test_composite_matches_weighted_formula(self):
+        scores = {
+            "factuality": 5, "novelty": 4, "source_diversity": 3,
+            "signal_density": 2, "coherence": 1,
+        }
+        # 0.30*5 + 0.20*4 + 0.15*3 + 0.20*2 + 0.15*1 = 1.5 + 0.8 + 0.45 + 0.4 + 0.15 = 3.30
+        self.assertAlmostEqual(store.composite(scores), 3.30, places=2)
+
+    def test_upsert_is_idempotent_on_key(self):
+        db = self._tmp_db()
+        scores = {"factuality": 4, "novelty": 4, "source_diversity": 4,
+                  "signal_density": 4, "coherence": 4, "notes": "first"}
+        store.upsert_run(card_date="2026-03-18", prompt_version="v1",
+                         judge_model="stub-v1", scores=scores, raw="r1", db_path=db)
+        scores["notes"] = "second"
+        scores["factuality"] = 5
+        store.upsert_run(card_date="2026-03-18", prompt_version="v1",
+                         judge_model="stub-v1", scores=scores, raw="r2", db_path=db)
+        rows = store.fetch_runs(db_path=db)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["notes"], "second")
+        self.assertEqual(rows[0]["factuality"], 5)
+        self.assertEqual(rows[0]["judge_raw"], "r2")
+
+
+class DriftTests(unittest.TestCase):
+    def setUp(self):
+        td = tempfile.mkdtemp(prefix="eval_drift_")
+        self.db = Path(td) / "store.sqlite"
+        # Patch the module default so drift+store read the temp DB.
+        store.DB_PATH_DEFAULT = self.db
+
+    def _seed(self, day_to_composite: dict[str, float], model: str = "stub-v1") -> None:
+        for day, comp in day_to_composite.items():
+            scores = {
+                "factuality": 3, "novelty": 3, "source_diversity": 3,
+                "signal_density": 3, "coherence": 3, "notes": "",
+            }
+            # Force composite by overriding through direct sqlite update.
+            store.upsert_run(card_date=day, prompt_version="v1",
+                             judge_model=model, scores=scores, raw="seed",
+                             db_path=self.db)
+            import sqlite3
+            with sqlite3.connect(self.db) as conn:
+                conn.execute(
+                    "UPDATE eval_runs SET composite = ? WHERE card_date = ? AND judge_model = ?",
+                    (comp, day, model),
+                )
+                conn.commit()
+
+    def test_no_alert_for_flat_history(self):
+        from datetime import date, timedelta
+        end = date(2026, 3, 18)
+        seed = {(end - timedelta(days=i)).isoformat(): 4.2 for i in range(30)}
+        self._seed(seed)
+        result = drift.evaluate("2026-03-18")
+        self.assertEqual(result["status"], "ok")
+
+    def test_alert_fires_on_recent_drop(self):
+        from datetime import date, timedelta
+        end = date(2026, 3, 18)
+        seed = {(end - timedelta(days=i)).isoformat(): 4.2 for i in range(8, 30)}
+        # last 8 days bad
+        for i in range(0, 8):
+            seed[(end - timedelta(days=i)).isoformat()] = 1.0
+        self._seed(seed)
+        result = drift.evaluate("2026-03-18")
+        self.assertEqual(result["status"], "alert")
+        self.assertGreaterEqual(len(result["alerts"]), 2)
+
+
+class ReportTests(unittest.TestCase):
+    def setUp(self):
+        td = tempfile.mkdtemp(prefix="eval_report_")
+        self.db = Path(td) / "store.sqlite"
+        store.DB_PATH_DEFAULT = self.db
+        scores = {"factuality": 4, "novelty": 4, "source_diversity": 4,
+                  "signal_density": 5, "coherence": 4, "notes": "ok"}
+        store.upsert_run(card_date="2026-03-18", prompt_version="v1",
+                         judge_model="stub-v1", scores=scores, raw="r",
+                         db_path=self.db)
+
+    def test_report_contains_headers_and_row(self):
+        md = report.build("2026-03-18", window=7)
+        self.assertIn("# Briefing Eval Report", md)
+        self.assertIn("Composite (median)", md)
+        self.assertIn("2026-03-18", md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,32 @@
+/* TEAM */
+Maintainer: Son Nguyen
+Aliases: David Nguyen, hoangsonww
+Site: https://sonnguyenhoang.com
+GitHub: https://github.com/hoangsonww
+LinkedIn: https://www.linkedin.com/in/hoangsonw/
+Location: Palo Alto, California, USA
+
+/* CONTRIBUTORS */
+See: https://github.com/hoangsonww/AI-News-Briefing/graphs/contributors
+
+/* THANKS */
+Anthropic — Claude + Claude Code, MCP protocol, prompt patterns
+OpenAI — Codex CLI
+Google — Gemini CLI
+GitHub — Copilot CLI, GitHub Actions, Pages hosting
+Microsoft — Teams Adaptive Cards, GitHub
+Notion — MCP server, Databases API
+Obsidian — Vault format, graph view, wikilinks
+
+/* SITE */
+Last update: 2026-05-13
+Standards: HTML5, CSS3, JSON-LD (schema.org), llms.txt, sitemap protocol 0.9, robots exclusion standard
+Components: vanilla CSS + ES modules (mermaid.js for diagrams), no build step
+Hosting: GitHub Pages
+License: MIT
+
+/* PROJECT */
+Repo: https://github.com/hoangsonww/AI-News-Briefing
+Wiki: https://hoangsonww.github.io/AI-News-Briefing/
+Docker image: ghcr.io/hoangsonww/ai-news-briefing
+Marketplace: claude-plugins/ + plugins/ + gemini-extensions/

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI News Briefing — Automated Daily AI News Pipeline + Research Ops Ecosystem | Wiki</title>
+  <title>AI News Briefing - Automated Daily AI News Pipeline + Research Ops Ecosystem | Wiki</title>
 
   <!-- Primary SEO -->
   <meta name="description" content="Open-source automated daily AI news briefing pipeline. Multi-engine (Claude, Codex, Gemini, Copilot), 10-plugin research ops ecosystem, Notion + Teams + Slack + Obsidian delivery, custom topic deep research, 201 tests, and a 5-axis LLM-as-judge quality eval harness.">
   <meta name="keywords" content="AI news briefing, automated AI news, Claude Code, Codex, Gemini CLI, Copilot CLI, Anthropic, OpenAI, agentic AI, multi-agent research, Notion MCP, Teams Adaptive Card, Slack Block Kit, Obsidian graph, knowledge graph, LLM-as-judge, eval harness, briefing automation, daily briefing, MCP server, plugin marketplace, deep research agent, research ops, hoangsonww">
   <meta name="author" content="Son Nguyen (hoangsonww)">
-  <meta name="copyright" content="© 2026 Son Nguyen — MIT License">
+  <meta name="copyright" content="© 2026 Son Nguyen - MIT License">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
   <meta name="googlebot" content="index, follow">
   <meta name="bingbot" content="index, follow">
@@ -33,12 +33,12 @@
   <link rel="canonical" href="https://hoangsonww.github.io/AI-News-Briefing/">
   <link rel="alternate" type="text/html" hreflang="en" href="https://hoangsonww.github.io/AI-News-Briefing/">
   <link rel="alternate" type="text/html" hreflang="x-default" href="https://hoangsonww.github.io/AI-News-Briefing/">
-  <link rel="alternate" type="application/rss+xml" title="AI News Briefing — Repo Activity" href="https://github.com/hoangsonww/AI-News-Briefing/commits/main.atom">
+  <link rel="alternate" type="application/rss+xml" title="AI News Briefing - Repo Activity" href="https://github.com/hoangsonww/AI-News-Briefing/commits/main.atom">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="AI News Briefing">
-  <meta property="og:title" content="AI News Briefing — Automated Daily AI News Pipeline + Research Ops Ecosystem">
+  <meta property="og:title" content="AI News Briefing - Automated Daily AI News Pipeline + Research Ops Ecosystem">
   <meta property="og:description" content="Open-source automated daily AI news briefing. Multi-engine CLI (Claude / Codex / Gemini / Copilot), 10-plugin research ops, Notion + Teams + Slack + Obsidian delivery, custom deep research, and a 5-axis LLM-as-judge quality eval harness.">
   <meta property="og:url" content="https://hoangsonww.github.io/AI-News-Briefing/">
   <meta property="og:image" content="https://hoangsonww.github.io/AI-News-Briefing/img/tests.png">
@@ -53,7 +53,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@hoangsonww">
   <meta name="twitter:creator" content="@hoangsonww">
-  <meta name="twitter:title" content="AI News Briefing — Automated Daily AI News Pipeline">
+  <meta name="twitter:title" content="AI News Briefing - Automated Daily AI News Pipeline">
   <meta name="twitter:description" content="Multi-engine AI news automation: Claude / Codex / Gemini / Copilot. Notion + Teams + Slack + Obsidian delivery, 10 research plugins, LLM-as-judge eval harness. MIT licensed.">
   <meta name="twitter:image" content="https://hoangsonww.github.io/AI-News-Briefing/img/tests.png">
   <meta name="twitter:image:alt" content="AI News Briefing test runner CLI output banner">
@@ -111,7 +111,7 @@
         "@type": "WebSite",
         "@id": "https://hoangsonww.github.io/AI-News-Briefing/#website",
         "url": "https://hoangsonww.github.io/AI-News-Briefing/",
-        "name": "AI News Briefing — Project Wiki",
+        "name": "AI News Briefing - Project Wiki",
         "description": "Comprehensive wiki for AI News Briefing: architecture, E2E flow, plugins, custom brief, eval harness, and operational runbook.",
         "inLanguage": "en",
         "publisher": { "@id": "https://github.com/hoangsonww#person" },
@@ -235,7 +235,7 @@
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
       View Obsidian Integration
     </a>
-    <a href="README.md" class="btn btn-secondary">
+    <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/README.md" class="btn btn-secondary">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
       Open README
     </a>
@@ -1194,8 +1194,8 @@ graph LR
       <tr><td>Graph Edges</td><td>Each <code>[[wikilink]]</code> creates a bidirectional edge in Obsidian's graph view</td></tr>
       <tr><td>Cross-Briefing Links</td><td>"Related Topics" header links all topics at top of each briefing for maximum connectivity</td></tr>
       <tr><td>Tags</td><td>YAML <code>tags</code> array enables tag-based filtering in Obsidian search</td></tr>
-      <tr><td>Env Variable</td><td><code>AI_BRIEFING_OBSIDIAN_VAULT</code> — absolute path to vault root directory</td></tr>
-      <tr><td>Local-First</td><td>No API, no cloud sync — files written directly to disk. Obsidian Sync is optional.</td></tr>
+      <tr><td>Env Variable</td><td><code>AI_BRIEFING_OBSIDIAN_VAULT</code> - absolute path to vault root directory</td></tr>
+      <tr><td>Local-First</td><td>No API, no cloud sync - files written directly to disk. Obsidian Sync is optional.</td></tr>
       </tbody>
     </table>
   </div>
@@ -1284,7 +1284,7 @@ flowchart TD
   </div>
 
   <div style="text-align: center; margin-top: 1.5rem;">
-    <a href="TESTS.md" class="btn btn-secondary">
+    <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/TESTS.md" class="btn btn-secondary">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
         <polyline points="14 2 14 8 20 8"/>
@@ -1384,13 +1384,13 @@ flowchart LR
       <tr><td><code>eval/drift.py</code></td><td>Median + MAD-based z-score across rolling windows; robust to small-sample outliers</td></tr>
       <tr><td><code>eval/report.py</code></td><td>Weekly Markdown digest: coverage, composite stats, axis medians, per-day table</td></tr>
       <tr><td><code>eval/golden/*.json</code></td><td>Pinned baseline composites for regression gate</td></tr>
-      <tr><td><code>eval/tests/</code></td><td>10 unittest cases against the stub backend — <code>make eval-test</code></td></tr>
+      <tr><td><code>eval/tests/</code></td><td>10 unittest cases against the stub backend - <code>make eval-test</code></td></tr>
       </tbody>
     </table>
   </div>
 
   <div style="text-align: center; margin-top: 1.5rem;">
-    <a href="eval/README.md" class="btn btn-secondary">
+    <a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/eval/README.md" class="btn btn-secondary">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
         <polyline points="14 2 14 8 20 8"/>
@@ -1439,55 +1439,55 @@ flowchart LR
 
   <div class="features">
     <div class="feature-card">
-      <h3><a href="README.md">README.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/README.md">README.md</a></h3>
       <p>User-facing setup, topic scope, scheduler installation, Makefile commands, Teams, Slack, and Obsidian delivery overview.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="ARCHITECTURE.md">ARCHITECTURE.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/ARCHITECTURE.md">ARCHITECTURE.md</a></h3>
       <p>Deep architecture walkthrough with component-level design decisions and operational constraints.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="E2E_FLOW.md">E2E_FLOW.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/E2E_FLOW.md">E2E_FLOW.md</a></h3>
       <p>Detailed end-to-end execution, sequence, failure paths, artifact contracts, and alignment options.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="NOTIFY_TEAMS.md">NOTIFY_TEAMS.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_TEAMS.md">NOTIFY_TEAMS.md</a></h3>
       <p>Teams webhook setup, multi-webhook configuration, Adaptive Card behavior, and troubleshooting delivery issues.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="scripts/teams-to-slack.py">scripts/teams-to-slack.py</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/scripts/teams-to-slack.py">scripts/teams-to-slack.py</a></h3>
       <p>Converter that transforms Teams Adaptive Card JSON into Slack Block Kit payloads for Slack webhook delivery.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="prompt.md">prompt.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/prompt.md">prompt.md</a></h3>
       <p>Agent instructions for search scope, formatting requirements, Notion write, and Obsidian markdown with [[wikilinks]].</p>
     </div>
     <div class="feature-card">
-      <h3><a href="CUSTOM_BRIEF.md">CUSTOM_BRIEF.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/CUSTOM_BRIEF.md">CUSTOM_BRIEF.md</a></h3>
       <p>Custom topic deep research: CLI usage, agent architecture, output formats, Obsidian graph support, and comparison with daily briefing.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="SETUP.md">SETUP.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/SETUP.md">SETUP.md</a></h3>
       <p>Full setup guide: AI CLI engines, Notion MCP, Obsidian vault, webhook configuration, scheduler install, and verification.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="NOTIFY_SLACK.md">NOTIFY_SLACK.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_SLACK.md">NOTIFY_SLACK.md</a></h3>
       <p>Slack webhook setup, Block Kit conversion, multi-webhook configuration, and troubleshooting.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="TESTS.md">TESTS.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/TESTS.md">TESTS.md</a></h3>
       <p>Test suite documentation: architecture, per-suite coverage tables (including Obsidian suite), run commands, design principles.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="eval/README.md">eval/README.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/eval/README.md">eval/README.md</a></h3>
       <p>Quality eval harness: 5-axis rubric, judge backends, SQLite store schema, drift detection, golden set regression, publish gate, and weekly report.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="LOGS.md">LOGS.md</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/LOGS.md">LOGS.md</a></h3>
       <p>Log tailing and management: live tail, read, search, summarize, export, and cleanup for daily and custom briefs.</p>
     </div>
     <div class="feature-card">
-      <h3><a href="Makefile">Makefile</a></h3>
+      <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/Makefile">Makefile</a></h3>
       <p>Cross-platform operator interface for run, schedule, custom-brief, log, validation, and status workflows.</p>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -3,13 +3,158 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI News Briefing - Project Wiki</title>
-  <meta name="description" content="Comprehensive wiki for AI News Briefing: architecture, E2E flow, operations, multi-channel delivery (Teams + Slack), Obsidian vault publishing with graph view, and maintenance runbook.">
+  <title>AI News Briefing — Automated Daily AI News Pipeline + Research Ops Ecosystem | Wiki</title>
+
+  <!-- Primary SEO -->
+  <meta name="description" content="Open-source automated daily AI news briefing pipeline. Multi-engine (Claude, Codex, Gemini, Copilot), 10-plugin research ops ecosystem, Notion + Teams + Slack + Obsidian delivery, custom topic deep research, 201 tests, and a 5-axis LLM-as-judge quality eval harness.">
+  <meta name="keywords" content="AI news briefing, automated AI news, Claude Code, Codex, Gemini CLI, Copilot CLI, Anthropic, OpenAI, agentic AI, multi-agent research, Notion MCP, Teams Adaptive Card, Slack Block Kit, Obsidian graph, knowledge graph, LLM-as-judge, eval harness, briefing automation, daily briefing, MCP server, plugin marketplace, deep research agent, research ops, hoangsonww">
+  <meta name="author" content="Son Nguyen (hoangsonww)">
+  <meta name="copyright" content="© 2026 Son Nguyen — MIT License">
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+  <meta name="googlebot" content="index, follow">
+  <meta name="bingbot" content="index, follow">
+  <meta name="referrer" content="no-referrer-when-downgrade">
+  <meta name="rating" content="general">
+  <meta name="theme-color" content="#0a0a0f">
+  <meta name="color-scheme" content="dark light">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="generator" content="Static HTML, hand-authored">
+  <meta name="application-name" content="AI News Briefing">
+  <meta name="apple-mobile-web-app-title" content="AI News Briefing">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="mobile-web-app-capable" content="yes">
+
+  <!-- Geo / language -->
+  <meta name="language" content="English">
+  <meta http-equiv="content-language" content="en">
+
+  <!-- Canonical + alternates -->
+  <link rel="canonical" href="https://hoangsonww.github.io/AI-News-Briefing/">
+  <link rel="alternate" type="text/html" hreflang="en" href="https://hoangsonww.github.io/AI-News-Briefing/">
+  <link rel="alternate" type="text/html" hreflang="x-default" href="https://hoangsonww.github.io/AI-News-Briefing/">
+  <link rel="alternate" type="application/rss+xml" title="AI News Briefing — Repo Activity" href="https://github.com/hoangsonww/AI-News-Briefing/commits/main.atom">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="AI News Briefing">
+  <meta property="og:title" content="AI News Briefing — Automated Daily AI News Pipeline + Research Ops Ecosystem">
+  <meta property="og:description" content="Open-source automated daily AI news briefing. Multi-engine CLI (Claude / Codex / Gemini / Copilot), 10-plugin research ops, Notion + Teams + Slack + Obsidian delivery, custom deep research, and a 5-axis LLM-as-judge quality eval harness.">
+  <meta property="og:url" content="https://hoangsonww.github.io/AI-News-Briefing/">
+  <meta property="og:image" content="https://hoangsonww.github.io/AI-News-Briefing/img/tests.png">
+  <meta property="og:image:alt" content="AI News Briefing test runner CLI output banner">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="720">
+  <meta property="og:locale" content="en_US">
+  <meta property="article:author" content="https://github.com/hoangsonww">
+  <meta property="article:publisher" content="https://github.com/hoangsonww">
+
+  <!-- Twitter / X Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@hoangsonww">
+  <meta name="twitter:creator" content="@hoangsonww">
+  <meta name="twitter:title" content="AI News Briefing — Automated Daily AI News Pipeline">
+  <meta name="twitter:description" content="Multi-engine AI news automation: Claude / Codex / Gemini / Copilot. Notion + Teams + Slack + Obsidian delivery, 10 research plugins, LLM-as-judge eval harness. MIT licensed.">
+  <meta name="twitter:image" content="https://hoangsonww.github.io/AI-News-Briefing/img/tests.png">
+  <meta name="twitter:image:alt" content="AI News Briefing test runner CLI output banner">
+  <meta name="twitter:url" content="https://hoangsonww.github.io/AI-News-Briefing/">
+
+  <!-- LinkedIn / Pinterest -->
+  <meta property="linkedin:owner" content="https://www.linkedin.com/in/hoangsonw/">
+  <meta property="pinterest:description" content="Open-source automated daily AI news briefing pipeline with multi-agent research and LLM-as-judge eval.">
+
+  <!-- Discovery files -->
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/AI-News-Briefing/sitemap.xml">
+  <link rel="manifest" href="/AI-News-Briefing/site.webmanifest">
+  <link rel="search" type="application/opensearchdescription+xml" title="AI News Briefing" href="/AI-News-Briefing/opensearch.xml">
+  <link rel="author" type="text/plain" href="/AI-News-Briefing/humans.txt">
+  <link rel="license" href="https://opensource.org/licenses/MIT">
+
+  <!-- DNS prefetch + preconnect -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+  <link rel="dns-prefetch" href="https://github.com">
+
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="wiki/style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+  <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>">
+
+  <!-- JSON-LD: SoftwareSourceCode + WebSite + Person -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareSourceCode",
+        "@id": "https://hoangsonww.github.io/AI-News-Briefing/#software",
+        "name": "AI News Briefing",
+        "alternateName": "AI News Briefing Research Ops Ecosystem",
+        "description": "Automated daily AI news briefing pipeline with multi-engine CLI execution (Claude, Codex, Gemini, Copilot), 10-plugin research ops ecosystem, Notion + Teams + Slack + Obsidian delivery, custom deep research agents, and a 5-axis LLM-as-judge quality eval harness.",
+        "codeRepository": "https://github.com/hoangsonww/AI-News-Briefing",
+        "url": "https://hoangsonww.github.io/AI-News-Briefing/",
+        "license": "https://opensource.org/licenses/MIT",
+        "programmingLanguage": ["Bash", "PowerShell", "Python", "Markdown"],
+        "runtimePlatform": ["macOS", "Linux", "Windows"],
+        "operatingSystem": ["macOS", "Linux", "Windows"],
+        "applicationCategory": "DeveloperApplication",
+        "keywords": "AI news, agentic AI, MCP, Claude Code, Codex, Gemini CLI, Notion, Teams, Slack, Obsidian, eval harness, LLM-as-judge, research ops",
+        "author": {
+          "@id": "https://github.com/hoangsonww#person"
+        },
+        "maintainer": {
+          "@id": "https://github.com/hoangsonww#person"
+        }
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://hoangsonww.github.io/AI-News-Briefing/#website",
+        "url": "https://hoangsonww.github.io/AI-News-Briefing/",
+        "name": "AI News Briefing — Project Wiki",
+        "description": "Comprehensive wiki for AI News Briefing: architecture, E2E flow, plugins, custom brief, eval harness, and operational runbook.",
+        "inLanguage": "en",
+        "publisher": { "@id": "https://github.com/hoangsonww#person" },
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://github.com/hoangsonww/AI-News-Briefing/search?q={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      },
+      {
+        "@type": "Person",
+        "@id": "https://github.com/hoangsonww#person",
+        "name": "Son Nguyen",
+        "alternateName": ["David Nguyen", "hoangsonww"],
+        "url": "https://sonnguyenhoang.com",
+        "sameAs": [
+          "https://github.com/hoangsonww",
+          "https://www.linkedin.com/in/hoangsonw/",
+          "https://sonnguyenhoang.com"
+        ],
+        "jobTitle": "Software Engineer",
+        "knowsAbout": ["Agentic AI", "LLM evaluation", "Claude Code", "MCP servers", "Knowledge graphs", "Research automation"]
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://hoangsonww.github.io/AI-News-Briefing/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Source",
+            "item": "https://github.com/hoangsonww/AI-News-Briefing"
+          }
+        ]
+      }
+    ]
+  }
+  </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
     mermaid.initialize({
@@ -54,7 +199,7 @@
         <path d="M4 22h16a2 2 0 002-2V4a2 2 0 00-2-2H8a2 2 0 00-2 2v16a2 2 0 01-2 2zm0 0a2 2 0 01-2-2v-9c0-1.1.9-2 2-2h2"/>
         <path d="M18 14h-8M15 18h-5M10 6h8v4h-8z"/>
       </svg>
-      AI News Briefing Wiki
+      AI News Briefing
     </a>
     <ul class="nav-links">
       <li><a href="#architecture">Architecture</a></li>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
       <li><a href="#delivery">Delivery</a></li>
       <li><a href="#obsidian">Obsidian</a></li>
       <li><a href="#tests">Tests</a></li>
+      <li><a href="#eval">Eval</a></li>
       <li><a href="#docs">Docs</a></li>
     </ul>
     <button class="nav-hamburger" aria-label="Toggle navigation">
@@ -82,7 +83,7 @@
   <h1>AI News Briefing<br><span class="gradient">Comprehensive Project Wiki</span></h1>
   <p class="hero-sub">
     End-to-end reference for the automated daily pipeline and on-demand deep research: scheduler triggers, multi-engine CLI execution (Claude, Codex, Gemini, Copilot),
-    multi-agent research, Notion publishing, Obsidian vault integration with graph visualization, Teams and Slack delivery, custom topic briefs, and maintenance workflows.
+    multi-agent research, Notion publishing, Obsidian vault integration with graph visualization, Teams and Slack delivery, custom topic briefs, a 5-axis LLM-as-judge quality eval harness, and maintenance workflows.
   </p>
   <div class="hero-actions">
     <a href="#obsidian" class="btn btn-primary">
@@ -1148,6 +1149,112 @@ flowchart TD
   </div>
 </section>
 
+<section class="section" id="eval">
+  <div class="section-header">
+    <div class="section-label">Quality Eval</div>
+    <h2 class="section-title">LLM-as-judge harness</h2>
+    <p class="section-desc">Every published briefing is silently scored on a 5-axis rubric so we catch prompt drift, source rot, and model regressions before readers notice. Backends shell out to the same CLIs the daily pipeline uses (Claude / Codex / Gemini); an offline <code>stub</code> backend lets tests and CI run with zero API cost.</p>
+    <p class="section-desc" style="margin-top: 1rem; color: #a78bfa;">
+      State lives in <code>eval/store.sqlite</code> keyed on <code>(card_date, prompt_version, judge_model)</code>. Switching judges or bumping the prompt appends rather than overwrites, so history stays apples-to-apples across rebaselines.
+    </p>
+  </div>
+
+  <div class="mermaid-wrap" style="margin-bottom: 2rem;">
+    <pre class="mermaid">
+flowchart LR
+    CARD["example-cards/&lt;date&gt;-card.json"] --> EX["extract.py\ntext + headlines + URLs"]
+    PRIOR["Prior 7 days\nof cards"] --> EX
+    EX --> JU["judge.py\nstub / claude / codex / gemini"]
+    JU --> RUN["runner.py\nscore | backfill | regression"]
+    RUN --> DB[("eval/store.sqlite")]
+    DB --> DR["drift.py\n7d vs 30d median ± MAD"]
+    DB --> RP["report.py\nweekly Markdown"]
+    RUN -- "--gate" --> PUB{"composite ≥ 3.0?"}
+    PUB -- yes --> OK["publish proceeds"]
+    PUB -- no --> BLOCK["abort, log composite"]
+    </pre>
+  </div>
+
+  <div class="table-wrap" style="max-width: 860px; margin: 0 auto 2rem;">
+    <table>
+      <thead>
+      <tr>
+        <th>Axis</th>
+        <th>Weight</th>
+        <th>What it measures</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr><td><code>factuality</code></td><td>0.30</td><td>Concrete claims map to cited sources (hard cap 2 if no sources)</td></tr>
+      <tr><td><code>novelty</code></td><td>0.20</td><td>New vs. prior 7-day window of cards</td></tr>
+      <tr><td><code>source_diversity</code></td><td>0.15</td><td>Distinct domains, primary + secondary mix</td></tr>
+      <tr><td><code>signal_density</code></td><td>0.20</td><td>Numbers, named entities, concrete outcomes per item</td></tr>
+      <tr><td><code>coherence</code></td><td>0.15</td><td>Thematic grouping with takeaways, not bullet soup</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="code-section" style="max-width: 780px; margin: 0 auto 1.5rem;">
+    <div class="code-header">
+      <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+      <span class="code-title">eval workflows</span>
+      <button class="code-copy">Copy</button>
+    </div>
+    <div class="code-body">
+<pre><span class="comment"># Score one card with the real Claude Haiku judge</span>
+<span class="cmd">make</span> eval D=2026-03-18 <span class="flag">JUDGE=claude</span>
+
+<span class="comment"># Score every card under example-cards/ in parallel (4 workers)</span>
+<span class="cmd">make</span> eval-backfill <span class="flag">JUDGE=claude</span>
+
+<span class="comment"># Re-score golden set, fail if any drops &gt; 0.5 composite points</span>
+<span class="cmd">make</span> eval-regression <span class="flag">JUDGE=claude</span>
+
+<span class="comment"># Drift check: 7d median vs 30d median ± MAD, exit 3 on alert</span>
+<span class="cmd">make</span> eval-drift D=2026-03-18 <span class="flag">ALERT_EXIT=1</span>
+
+<span class="comment"># Weekly Markdown report</span>
+<span class="cmd">make</span> eval-report D=2026-03-18 W=7 OUT=logs/eval-week.md
+
+<span class="comment"># Optional publish gate (exit 2 if composite &lt; 3.0)</span>
+<span class="cmd">python3</span> eval/runner.py score --date <span class="str">"$DATE"</span> --judge claude <span class="flag">--gate</span></pre>
+    </div>
+  </div>
+
+  <div class="table-wrap" style="max-width: 860px; margin: 0 auto;">
+    <table>
+      <thead>
+      <tr>
+        <th>Component</th>
+        <th>Role</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr><td><code>eval/rubric.md</code></td><td>5-axis definitions, weights, pass thresholds (publish gate, regression gate, drift alert)</td></tr>
+      <tr><td><code>eval/judge_prompt.md</code></td><td>Versioned judge prompt (v1). PROMPT_VERSION is part of the store key.</td></tr>
+      <tr><td><code>eval/extract.py</code></td><td>Adaptive-card JSON → flat text + headlines + source URLs; pulls prior 7 days for novelty</td></tr>
+      <tr><td><code>eval/judge.py</code></td><td>Backends: stub (offline heuristic), claude, codex, gemini. Per-call trace to <code>logs/eval-judge-YYYY-MM-DD.log</code>.</td></tr>
+      <tr><td><code>eval/store.py</code> + <code>schema.sql</code></td><td>SQLite, idempotent upsert on <code>(card_date, prompt_version, judge_model)</code></td></tr>
+      <tr><td><code>eval/runner.py</code></td><td>CLI: <code>score</code> / <code>backfill</code> (parallel <code>--workers</code>) / <code>regression</code> / <code>show</code>, with optional <code>--gate</code></td></tr>
+      <tr><td><code>eval/drift.py</code></td><td>Median + MAD-based z-score across rolling windows; robust to small-sample outliers</td></tr>
+      <tr><td><code>eval/report.py</code></td><td>Weekly Markdown digest: coverage, composite stats, axis medians, per-day table</td></tr>
+      <tr><td><code>eval/golden/*.json</code></td><td>Pinned baseline composites for regression gate</td></tr>
+      <tr><td><code>eval/tests/</code></td><td>10 unittest cases against the stub backend — <code>make eval-test</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div style="text-align: center; margin-top: 1.5rem;">
+    <a href="eval/README.md" class="btn btn-secondary">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+        <polyline points="14 2 14 8 20 8"/>
+      </svg>
+      Full eval harness documentation: eval/README.md
+    </a>
+  </div>
+</section>
+
 <section class="section" id="cost">
   <div class="section-header">
     <div class="section-label">Cost & Runtime</div>
@@ -1227,6 +1334,10 @@ flowchart TD
       <p>Test suite documentation: architecture, per-suite coverage tables (including Obsidian suite), run commands, design principles.</p>
     </div>
     <div class="feature-card">
+      <h3><a href="eval/README.md">eval/README.md</a></h3>
+      <p>Quality eval harness: 5-axis rubric, judge backends, SQLite store schema, drift detection, golden set regression, publish gate, and weekly report.</p>
+    </div>
+    <div class="feature-card">
       <h3><a href="LOGS.md">LOGS.md</a></h3>
       <p>Log tailing and management: live tail, read, search, summarize, export, and cleanup for daily and custom briefs.</p>
     </div>
@@ -1252,6 +1363,12 @@ flowchart TD
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file" style="color:#a78bfa;">test-obsidian.sh / .ps1</span> <span class="dim"># Obsidian vault connectivity test</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">teams-to-slack.py</span> <span class="dim"># Adaptive Card to Block Kit converter</span></div>
     <div>&nbsp;&nbsp;<span class="dir" style="color:#6366f1;">tests/</span> <span class="dim"># 201 non-blocking tests (bash + PowerShell)</span></div>
+    <div>&nbsp;&nbsp;<span class="dir" style="color:#a78bfa;">eval/</span> <span class="dim"># LLM-as-judge quality harness</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">rubric.md / judge_prompt.md</span> <span class="dim"># versioned scoring spec</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">extract.py / judge.py / store.py</span> <span class="dim"># card → score → sqlite</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">runner.py / drift.py / report.py</span> <span class="dim"># CLI + drift + weekly report</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">golden/*.json</span> <span class="dim"># pinned regression baselines</span></div>
+    <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="dir">tests/</span> <span class="dim"># 10 unittest cases against stub backend</span></div>
     <div>&nbsp;&nbsp;<span class="dir">logs/</span> <span class="dim"># runtime output (gitignored)</span></div>
     <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="file">covered-stories.txt</span> <span class="dim"># dedup headline tracker</span></div>
     <div>&nbsp;&nbsp;<span class="file">README.md</span> <span class="dim"># setup + usage</span></div>
@@ -1260,6 +1377,7 @@ flowchart TD
     <div>&nbsp;&nbsp;<span class="file" style="color:#6366f1;">SETUP.md</span> <span class="dim"># full setup guide</span></div>
     <div>&nbsp;&nbsp;<span class="file">E2E_FLOW.md</span> <span class="dim"># execution contracts</span></div>
     <div>&nbsp;&nbsp;<span class="file">NOTIFY_TEAMS.md / NOTIFY_SLACK.md</span> <span class="dim"># integration guides</span></div>
+    <div>&nbsp;&nbsp;<span class="file" style="color:#a78bfa;">eval/README.md</span> <span class="dim"># quality eval harness manual</span></div>
     <div>&nbsp;&nbsp;<span class="file">index.html</span> <span class="dim"># this wiki page</span></div>
   </div>
 </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,51 @@
+# AI News Briefing
+
+> Open-source automated daily AI news briefing pipeline. Multi-engine CLI (Claude, Codex, Gemini, Copilot) drives an agentic prompt that searches the web, deduplicates against prior coverage, compiles a two-tier briefing, and publishes to Notion, Microsoft Teams, Slack, and an Obsidian vault. Ships with a 10-plugin research ops ecosystem and a 5-axis LLM-as-judge quality eval harness.
+
+- Repo: https://github.com/hoangsonww/AI-News-Briefing
+- Wiki: https://hoangsonww.github.io/AI-News-Briefing/
+- License: MIT
+- Maintainer: Son Nguyen (hoangsonww)
+
+This file follows the [llms.txt](https://llmstxt.org) convention so AI assistants and language models can find authoritative project documentation directly. Markdown links point at the canonical source for each topic.
+
+## Core documentation
+
+- [README](https://github.com/hoangsonww/AI-News-Briefing/blob/main/README.md): User-facing setup, topic scope, scheduler installation, Makefile commands, Teams + Slack + Obsidian delivery overview.
+- [ARCHITECTURE](https://github.com/hoangsonww/AI-News-Briefing/blob/main/ARCHITECTURE.md): Component-level architecture, design decisions, operational constraints, and the eval harness section (§3.14).
+- [E2E_FLOW](https://github.com/hoangsonww/AI-News-Briefing/blob/main/E2E_FLOW.md): End-to-end execution contract — trigger, AI execution, delivery pipelines, post-publish eval gate, failure paths.
+- [SETUP](https://github.com/hoangsonww/AI-News-Briefing/blob/main/SETUP.md): Full setup guide for all four AI CLI engines, Notion MCP, Obsidian vault, webhooks, scheduler install, verification.
+- [TESTS](https://github.com/hoangsonww/AI-News-Briefing/blob/main/TESTS.md): 201 non-blocking tests across Bash and PowerShell, plus 10 Python unittest cases for the eval harness.
+- [LOGS](https://github.com/hoangsonww/AI-News-Briefing/blob/main/LOGS.md): Log tailing, search, summarize, export, cleanup.
+
+## Custom topic research
+
+- [CUSTOM_BRIEF](https://github.com/hoangsonww/AI-News-Briefing/blob/main/CUSTOM_BRIEF.md): Custom topic deep research CLI, multi-agent prompt architecture, Notion + Obsidian publishing, comparison with the daily briefing.
+- [prompt-custom-brief.md](https://github.com/hoangsonww/AI-News-Briefing/blob/main/prompt-custom-brief.md): The multi-agent research prompt template (Agents 1–5, Phases 1–3).
+
+## Plugin ecosystem (10 plugins for Claude Code / Codex / Gemini)
+
+- [PLUGINS](https://github.com/hoangsonww/AI-News-Briefing/blob/main/PLUGINS.md): Plugin developer manual.
+- [claude-plugins/README](https://github.com/hoangsonww/AI-News-Briefing/blob/main/claude-plugins/README.md): Claude Code marketplace + plugin layout.
+- [Marketplace manifest](https://github.com/hoangsonww/AI-News-Briefing/blob/main/.claude-plugin/marketplace.json): Catalog (ai-news-briefing, last30days, trend-spotter, earnings-analyzer, paper-reader, competitor-intel, repo-auditor, podcast-summarizer, startup-scout, crypto-tracker).
+- [Codex plugins](https://github.com/hoangsonww/AI-News-Briefing/blob/main/plugins/README.md): Mirrored 10-plugin ecosystem for the Codex CLI.
+- [Gemini extensions](https://github.com/hoangsonww/AI-News-Briefing/tree/main/gemini-extensions): Gemini CLI extension manifests.
+
+## Delivery integrations
+
+- [NOTIFY_TEAMS](https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_TEAMS.md): Teams webhook setup, Adaptive Card schema, multi-webhook configuration.
+- [NOTIFY_SLACK](https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_SLACK.md): Slack webhook setup, Teams-to-Block-Kit conversion, troubleshooting.
+- [teams-to-slack.py](https://github.com/hoangsonww/AI-News-Briefing/blob/main/scripts/teams-to-slack.py): Pure-stdlib Python converter from Microsoft Teams Adaptive Card JSON to Slack Block Kit.
+
+## Quality eval harness
+
+- [eval/README](https://github.com/hoangsonww/AI-News-Briefing/blob/main/eval/README.md): 5-axis rubric (factuality, novelty, source diversity, signal density, coherence), judge backends (stub / claude / codex / gemini), SQLite store schema, drift detection, golden-set regression, publish gate, weekly Markdown report.
+- [eval/rubric.md](https://github.com/hoangsonww/AI-News-Briefing/blob/main/eval/rubric.md): Axis definitions, weights, pass thresholds.
+- [eval/judge_prompt.md](https://github.com/hoangsonww/AI-News-Briefing/blob/main/eval/judge_prompt.md): Versioned judge prompt (v1).
+
+## Optional
+
+- [Makefile](https://github.com/hoangsonww/AI-News-Briefing/blob/main/Makefile): Cross-platform operator interface — run, schedule, custom brief, eval, log, validation, status.
+- [Docker](https://github.com/hoangsonww/AI-News-Briefing/blob/main/Dockerfile): Containerized runtime, GHCR-published image.
+- [example-cards/](https://github.com/hoangsonww/AI-News-Briefing/tree/main/example-cards): Real adaptive-card JSON outputs from past daily runs, used by the eval harness for backfill.
+- [Contact](https://sonnguyenhoang.com): Maintainer site for Son Nguyen.

--- a/opensearch.xml
+++ b/opensearch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>AI News Briefing</ShortName>
+  <Description>Search the AI News Briefing project, docs, and source code.</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/svg+xml">data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'&gt;&lt;text y='.9em' font-size='90'&gt;📰&lt;/text&gt;&lt;/svg&gt;</Image>
+  <Url type="text/html" method="get" template="https://github.com/hoangsonww/AI-News-Briefing/search?q={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="https://hoangsonww.github.io/AI-News-Briefing/opensearch.xml"/>
+  <moz:SearchForm>https://github.com/hoangsonww/AI-News-Briefing/search</moz:SearchForm>
+</OpenSearchDescription>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,43 @@
+# robots.txt for https://hoangsonww.github.io/AI-News-Briefing/
+# Project: AI News Briefing (https://github.com/hoangsonww/AI-News-Briefing)
+# Maintainer: Son Nguyen (hoangsonww)
+
+User-agent: *
+Allow: /
+
+# Encourage indexing of structured data + docs
+Allow: /AI-News-Briefing/index.html
+Allow: /AI-News-Briefing/llms.txt
+Allow: /AI-News-Briefing/sitemap.xml
+Allow: /AI-News-Briefing/README.md
+Allow: /AI-News-Briefing/ARCHITECTURE.md
+Allow: /AI-News-Briefing/E2E_FLOW.md
+Allow: /AI-News-Briefing/TESTS.md
+Allow: /AI-News-Briefing/PLUGINS.md
+Allow: /AI-News-Briefing/eval/
+
+# Keep transient runtime + caches out of the index
+Disallow: /AI-News-Briefing/logs/
+Disallow: /AI-News-Briefing/backups/
+Disallow: /AI-News-Briefing/.claude/
+Disallow: /AI-News-Briefing/.agents/
+Disallow: /AI-News-Briefing/eval/store.sqlite
+
+# AI-specific crawlers — opt in (documentation, not training data)
+User-agent: GPTBot
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: Claude-Web
+Allow: /
+User-agent: PerplexityBot
+Allow: /
+User-agent: Google-Extended
+Allow: /
+User-agent: anthropic-ai
+Allow: /
+User-agent: cohere-ai
+Allow: /
+
+Sitemap: https://hoangsonww.github.io/AI-News-Briefing/sitemap.xml
+Host: https://hoangsonww.github.io/AI-News-Briefing/

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,56 @@
+{
+  "name": "AI News Briefing",
+  "short_name": "AI News",
+  "description": "Open-source automated daily AI news briefing pipeline with multi-engine CLI execution, 10-plugin research ops ecosystem, multi-channel delivery, and a 5-axis LLM-as-judge quality eval harness.",
+  "start_url": "/AI-News-Briefing/",
+  "scope": "/AI-News-Briefing/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0a0a0f",
+  "theme_color": "#0a0a0f",
+  "lang": "en",
+  "dir": "ltr",
+  "categories": ["productivity", "developer", "news", "ai", "research"],
+  "icons": [
+    {
+      "src": "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📰</text></svg>",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "img/tests.png",
+      "type": "image/png",
+      "sizes": "1280x720",
+      "form_factor": "wide",
+      "label": "AI News Briefing test runner CLI output"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Architecture",
+      "url": "/AI-News-Briefing/#architecture"
+    },
+    {
+      "name": "Plugins",
+      "url": "/AI-News-Briefing/#plugins"
+    },
+    {
+      "name": "Eval Harness",
+      "url": "/AI-News-Briefing/#eval"
+    },
+    {
+      "name": "GitHub",
+      "url": "https://github.com/hoangsonww/AI-News-Briefing"
+    }
+  ],
+  "related_applications": [
+    {
+      "platform": "webapp",
+      "url": "https://hoangsonww.github.io/AI-News-Briefing/"
+    }
+  ],
+  "prefer_related_applications": false
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
 
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -12,61 +12,61 @@
   <!-- Top-level docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/README.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/ARCHITECTURE.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/E2E_FLOW.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/SETUP.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/TESTS.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/PLUGINS.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/LOGS.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/CUSTOM_BRIEF.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_TEAMS.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_SLACK.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -74,19 +74,19 @@
   <!-- Eval harness docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/README.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/rubric.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/judge_prompt.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -94,13 +94,13 @@
   <!-- Plugin ecosystem -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/claude-plugins/README.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/plugins/README.md</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -108,13 +108,13 @@
   <!-- Discovery / SEO assets -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/llms.txt</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/humans.txt</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <!-- Top-level docs -->
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/README.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/ARCHITECTURE.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/E2E_FLOW.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/SETUP.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/TESTS.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/PLUGINS.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/LOGS.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/CUSTOM_BRIEF.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_TEAMS.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_SLACK.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Eval harness docs -->
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/README.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/rubric.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/judge_prompt.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <!-- Plugin ecosystem -->
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/claude-plugins/README.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/plugins/README.md</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Discovery / SEO assets -->
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/llms.txt</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://hoangsonww.github.io/AI-News-Briefing/humans.txt</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+</urlset>

--- a/wiki/style.css
+++ b/wiki/style.css
@@ -905,7 +905,7 @@ a:hover {
 }
 
 /* ===== Responsive ===== */
-@media (max-width: 1200px) {
+@media (max-width: 1400px) {
   .nav-links {
     display: flex;
     position: absolute;
@@ -933,7 +933,9 @@ a:hover {
   .nav-hamburger {
     display: block;
   }
+}
 
+@media (max-width: 1200px) {
   .hero {
     padding: 8rem 1.5rem 3rem;
   }


### PR DESCRIPTION
This pull request introduces a comprehensive, automated quality evaluation harness for AI News Briefing, centered around a new `eval/` directory. The harness uses LLM-as-judge scoring on a 5-axis rubric to assess every published briefing, stores results in SQLite, detects quality drift, and provides regression and reporting pipelines. It is fully integrated into project documentation, the Makefile, and test infrastructure, and supports both offline (stub) and real LLM judge backends.

**Key changes:**

### Quality Evaluation Harness (eval/)
- Added a new `eval/` directory containing scripts and documentation for the quality evaluation harness, including a 5-axis rubric, judge prompt, SQLite schema, card extract/judge/store/report/runner/drift scripts, golden baseline set, and unit tests. The harness can run against both a deterministic stub backend and real LLMs (Claude, Codex, Gemini). [[1]](diffhunk://#diff-200b06e6451b0ae17aabf76d04d151b2b212a01c053dfa5570c110f0ca5165acR1-R162) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R848-R860)

### Documentation & Architecture
- Updated `README.md`, `ARCHITECTURE.md`, and `E2E_FLOW.md` to document the eval harness, its scoring rubric, pipelines (score, backfill, regression, drift, report), publish gate integration, storage schema, and design decisions. Includes diagrams and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R702-R730) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R848-R860) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR821-R925) [[4]](diffhunk://#diff-6ed6f431e7e2f9715b787e31ff82e523f536267c19bd35e3b2315291edce7205R283-R313)
- Added a dedicated `eval/README.md` with detailed instructions, rationale, and file map.

### Makefile Integration
- Added Make targets for all eval harness operations: scoring, backfill, regression, drift detection, report generation, golden set seeding, and unit testing. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R251-R288)
- Updated `README.md` to document new Make targets and their parameters.

### Testing
- Added Python unittest suite for the eval harness (`eval/tests/test_harness.py`), fully offline-testable, with Make target and documentation in `TESTS.md`. [[1]](diffhunk://#diff-6129e4842294d2f7cbef7f74cda4f4457150fa9c642210659bffbdb51c092994L85-R93) [[2]](diffhunk://#diff-6129e4842294d2f7cbef7f74cda4f4457150fa9c642210659bffbdb51c092994R249-R278) [[3]](diffhunk://#diff-6129e4842294d2f7cbef7f74cda4f4457150fa9c642210659bffbdb51c092994R359-R361)

### Security & Metadata
- Added a `.well-known/security.txt` file with project security contact and policy information.