### PR TITLE
fix(briefing): cd to project dir + trust flags so launchd runs produce output

### DIFF
--- a/briefing.sh
+++ b/briefing.sh
@@ -14,6 +14,11 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
 
+# The prompt tells the engine to read/write relative paths (logs/covered-stories.txt,
+# logs/$DATE-card.json, etc). Under launchd the cwd is "/", so those resolve to /logs
+# and fail read-only. Pin cwd to the project dir so every engine sees the real logs/.
+cd "$SCRIPT_DIR" || { echo "ERROR: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
+
 # -- Argument parsing ------------------------------------------
 CLI_ARG=""
 DATE_ARG=""
@@ -116,11 +121,13 @@ run_engine() {
         "$prompt" >> "$LOG_FILE" 2>&1
       ;;
     codex)
-      "$binary" exec --full-auto \
+      # --skip-git-repo-check: under launchd codex can't confirm a trusted dir
+      "$binary" exec --full-auto --skip-git-repo-check \
         "$prompt" >> "$LOG_FILE" 2>&1
       ;;
     gemini)
-      "$binary" -p \
+      # --skip-trust: non-interactive runs aren't in a "trusted" workspace by default
+      "$binary" --skip-trust -p \
         "$prompt" >> "$LOG_FILE" 2>&1
       ;;
     copilot)


### PR DESCRIPTION
## Summary

Fixes the empty 8 AM cron runs. `briefing.sh` computed `SCRIPT_DIR` but never `cd`'d into it. The prompt instructs each engine to read/write **relative** paths (`logs/covered-stories.txt`, `logs/$DATE-card.json`, `logs/$DATE-obsidian.md`). Under launchd the cwd is `/`, so those resolved to `/logs` and failed read-only — `claude` reported "filesystem read-only", `copilot` logged `Read /logs -> Path does not exist`. Interactive runs masked this because the cwd was already the repo.

## Changes

- `cd "$SCRIPT_DIR"` at startup so every engine sees the real `logs/` dir.
- `codex`: add `--skip-git-repo-check` (the launchd dir isn't a "trusted" dir).
- `gemini`: add `--skip-trust` (non-interactive runs aren't trusted by default).

## Verification

Simulated the launchd environment by forcing cwd to `/`:

```
cd / && AI_BRIEFING_MODEL=claude-haiku-4-5-20251001 \
  briefing.sh --cli claude --date 2026-05-29
```

Result: `claude` + Haiku produced `logs/2026-05-29-card.json` and `logs/2026-05-29-obsidian.md`, and the Slack notification was delivered (HTTP 200). Exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)