### PR TITLE
feat(briefing): wake catch-up for missed 8 AM runs + run lock

### DIFF
--- a/E2E_FLOW.md
+++ b/E2E_FLOW.md
@@ -157,6 +157,7 @@ sequenceDiagram
 | Scheduler | `com.ainews.briefing.plist` | Task `AiNewsBriefing` via `install-task.ps1` |
 | Entry script | `briefing.sh` | `briefing.ps1` |
 | Default schedule | 08:00 daily | 08:00 daily |
+| Sleep/wake catch-up | `StartInterval` (30 min) runs `briefing.sh --catchup` -- covers a run missed by sleeping through 8 AM on the next wake the same day; never back-fills | `StartWhenAvailable` runs the task on next wake/login |
 | Manual trigger | `make run`, `make run-bg`, `make run-scheduled` | same Make targets, or `schtasks /run /tn AiNewsBriefing` |
 
 Entry scripts do the same core setup:

--- a/LOGS.md
+++ b/LOGS.md
@@ -15,6 +15,7 @@ Complete guide to monitoring, searching, and managing logs for both the daily au
 | Dedup tracker | `logs/covered-stories.txt` | (single file, appended daily) |
 | launchd stdout | `logs/launchd-stdout.log` | (macOS only, single file) |
 | launchd stderr | `logs/launchd-stderr.log` | (macOS only, single file) |
+| Run lock | `logs/.briefing.lock/` | (transient dir; held during a run, auto-cleared on exit or if >3h stale) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -215,12 +215,14 @@ To customize the time:
 
 ### Change the schedule
 
-**macOS:** Edit `com.ainews.briefing.plist` and modify the `StartCalendarInterval` section, then reload:
+**macOS:** Edit `com.ainews.briefing.plist` and modify the `StartCalendarInterval` section (the daily run time), then reload:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.ainews.briefing.plist
 launchctl load ~/Library/LaunchAgents/com.ainews.briefing.plist
 ```
+
+The plist also carries a `StartInterval` (every 30 min) that drives the sleep/wake **catch-up** -- it runs `briefing.sh --catchup`, which only acts when today's briefing hasn't run yet and it's past 08:00. Leave it in place; it is what recovers a run missed because the Mac was asleep at 8 AM. To change the catch-up cadence, edit the `StartInterval` integer (seconds).
 
 **Windows:** Re-run the installer with new time parameters:
 
@@ -814,8 +816,10 @@ This error occurs when the `CLAUDECODE` environment variable is set, which happe
 
 **macOS (launchd):**
 
-- **Mac was asleep:** launchd will run the job when the Mac wakes up if the scheduled time was missed. If Power Nap is disabled or the lid was closed, the job may not fire until the next login.
-- **Powered off at scheduled time:** The job is skipped entirely for that day.
+- **Mac was asleep at 8 AM:** The job is registered with both `StartCalendarInterval` (8 AM) and `StartInterval` (every 30 min). If the Mac sleeps through 8 AM, launchd fires the missed interval on the next wake, and `briefing.sh --catchup` runs that day's briefing as long as it is at/after 08:00 and the briefing has not already run. So a sleep-through-8 AM is covered automatically on the next wake **the same day**.
+- **Mac stayed asleep until a later day:** The missed day is treated as gone -- `--catchup` always targets the current date and never back-fills. Whenever the Mac next wakes (past 08:00) it runs *that* day's briefing only.
+- **Already ran today:** Catch-up exits immediately if `logs/YYYY-MM-DD-card.json` already exists, so the 30-min interval never double-posts.
+- **Powered off at scheduled time:** Same as above -- the job runs once on next boot/wake for the current day; earlier days are skipped.
 - **Agent not loaded:** Verify with `launchctl list | grep ainews`. If missing, reload the plist.
 - **Path issues:** The plist sets a custom `PATH` and `HOME`. If Claude is installed in a non-standard location, update the `PATH` in the plist.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -120,6 +120,25 @@ export AI_BRIEFING_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../...
 [Environment]::SetEnvironmentVariable("AI_BRIEFING_SLACK_WEBHOOK", "https://hooks.slack.com/services/T.../B.../...", "User")
 ```
 
+> **macOS persistence — two separate places.** A bare `export` only lives in the
+> current shell. For it to survive new shells **and** the scheduled run you must set
+> it in both:
+> - **`~/.zshenv`** — sourced by every zsh (interactive and non-interactive), so
+>   manual runs and `scripts/notify-slack.sh` pick it up:
+>   ```bash
+>   echo 'export AI_BRIEFING_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../..."' >> ~/.zshenv
+>   chmod 600 ~/.zshenv   # it holds a secret
+>   ```
+> - **The launchd plist `EnvironmentVariables` block** — launchd does **not** read
+>   shell profiles, so the 8 AM / catch-up job only sees the webhook if it is listed
+>   there. Add it to your installed `~/Library/LaunchAgents/com.ainews.briefing.plist`
+>   (do **not** commit a real webhook into the checked-in plist):
+>   ```xml
+>   <key>AI_BRIEFING_SLACK_WEBHOOK</key>
+>   <string>https://hooks.slack.com/services/T.../B.../...</string>
+>   ```
+>   Then reload: `launchctl bootout gui/$(id -u)/com.ainews.briefing 2>/dev/null; launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ainews.briefing.plist`
+
 ### Multiple Webhooks
 
 Separate multiple URLs with semicolons:
@@ -178,6 +197,17 @@ cp com.ainews.briefing.plist ~/Library/LaunchAgents/
 launchctl load ~/Library/LaunchAgents/com.ainews.briefing.plist
 launchctl list | grep ainews
 ```
+
+**Scheduling model.** The plist runs `briefing.sh --catchup` and registers two triggers:
+- `StartCalendarInterval` (08:00) — the punctual daily run when the Mac is awake.
+- `StartInterval` (1800s) — the **catch-up**. launchd fires a missed interval on the
+  next wake; with `--catchup` the script runs today's briefing only if it hasn't run
+  yet (`logs/YYYY-MM-DD-card.json` is absent) and the clock is at/after 08:00.
+
+Net effect: asleep through 8 AM → the briefing runs on the next wake **the same day**;
+a day the Mac never opens is skipped (no back-fill); already-ran days never double-post.
+A `logs/.briefing.lock` directory guards against overlapping fires and is auto-cleared
+(including a stale lock older than 3h from a crashed run).
 
 ### Windows (Task Scheduler)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -209,6 +209,13 @@ a day the Mac never opens is skipped (no back-fill); already-ran days never doub
 A `logs/.briefing.lock` directory guards against overlapping fires and is auto-cleared
 (including a stale lock older than 3h from a crashed run).
 
+> **Model matters for the Notion step.** The plist sets `AI_BRIEFING_MODEL` to a
+> capable model (`claude-sonnet-4-6`). A weaker model (e.g. Haiku) has been observed
+> to ignore the `parent` in `prompt.md` Step 3 and create an **orphan workspace page**
+> that never lands in the database. If you change the model, pick one strong enough to
+> follow the Notion `create-pages` parameters exactly, or briefings won't be tracked
+> in the database. To change it, edit the `AI_BRIEFING_MODEL` string and reload.
+
 ### Windows (Task Scheduler)
 
 ```powershell

--- a/briefing.sh
+++ b/briefing.sh
@@ -22,6 +22,7 @@ cd "$SCRIPT_DIR" || { echo "ERROR: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
 # -- Argument parsing ------------------------------------------
 CLI_ARG=""
 DATE_ARG=""
+CATCHUP=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,6 +32,11 @@ while [[ $# -gt 0 ]]; do
     --date|-d)
       [[ $# -lt 2 ]] && { echo "ERROR: --date requires a value" >&2; exit 1; }
       DATE_ARG="$2"; shift 2 ;;
+    --catchup)
+      # Scheduled-trigger mode: run today's briefing only if it hasn't run yet
+      # and it's at/after 08:00. Lets launchd fire this on every wake without
+      # double-posting or back-filling days the machine was asleep through.
+      CATCHUP=true; shift ;;
     --help|-h)
       cat <<'USAGE'
 Usage: briefing.sh [OPTIONS] [DATE]
@@ -40,6 +46,9 @@ Run the daily AI news briefing pipeline.
 Options:
   --cli, -c ENGINE   AI engine: claude, codex, gemini, copilot
   --date, -d DATE    Briefing date (YYYY-MM-DD), default: today
+  --catchup          Scheduled mode: run today only if not already done and
+                     it's at/after 08:00 (skips if asleep through 8am until
+                     next wake same day; never back-fills missed days)
   --help, -h         Show this help
 
 Environment:
@@ -68,6 +77,37 @@ mkdir -p "$LOG_DIR"
 write_log() {
   echo "[$DATE $(date +%H:%M:%S)] $1" >> "$LOG_FILE"
 }
+
+# -- Catch-up guard (scheduled --catchup runs only) ------------
+# Goal: 8am run when awake; if asleep at 8am, run on the next wake THAT day;
+# if the machine isn't opened until a later day, treat the missed day as gone
+# (the run always targets the current date, so it never back-fills).
+if [[ "$CATCHUP" == "true" ]]; then
+  if [ -f "$LOG_DIR/$DATE-card.json" ]; then
+    write_log "Catch-up: briefing for $DATE already done; skipping."
+    exit 0
+  fi
+  HHMM=$(date +%H%M)
+  if (( 10#$HHMM < 800 )); then
+    write_log "Catch-up: before 08:00 (now $HHMM); deferring to the scheduled run."
+    exit 0
+  fi
+  write_log "Catch-up: no briefing yet for $DATE and now is $HHMM; running."
+fi
+
+# -- Single-run lock -------------------------------------------
+# Prevent overlap when the 8am calendar fire and a wake-triggered interval
+# fire (or two interval ticks) land close together. mkdir is atomic.
+LOCK_DIR="$LOG_DIR/.briefing.lock"
+if [ -d "$LOCK_DIR" ] && find "$LOCK_DIR" -prune -mmin +180 2>/dev/null | grep -q .; then
+  write_log "Removing stale lock (>3h old) from a crashed run."
+  rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+fi
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  write_log "Another briefing run holds the lock; exiting."
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
 
 write_log "Starting AI News Briefing..."
 

--- a/com.ainews.briefing.plist
+++ b/com.ainews.briefing.plist
@@ -55,7 +55,7 @@
         <key>HOME</key>
         <string>/Users/davidnguyen</string>
         <key>AI_BRIEFING_MODEL</key>
-        <string>claude-haiku-4-5-20251001</string>
+        <string>claude-sonnet-4-6</string>
     </dict>
 </dict>
 </plist>

--- a/com.ainews.briefing.plist
+++ b/com.ainews.briefing.plist
@@ -23,8 +23,10 @@
     <array>
         <string>/bin/bash</string>
         <string>/Users/davidnguyen/ai-news-briefing/briefing.sh</string>
+        <string>--catchup</string>
     </array>
 
+    <!-- Punctual 8am run when the machine is awake. -->
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>
@@ -32,6 +34,13 @@
         <key>Minute</key>
         <integer>0</integer>
     </dict>
+
+    <!-- Catch-up: launchd fires a missed interval on the next wake. With
+         --catchup the script runs today only if not already done and it's
+         past 08:00, so a sleep-through-8am gets covered on wake the same day,
+         while a day the machine never opened is simply skipped. -->
+    <key>StartInterval</key>
+    <integer>1800</integer>
 
     <key>StandardOutPath</key>
     <string>/Users/davidnguyen/ai-news-briefing/logs/launchd-stdout.log</string>

--- a/prompt.md
+++ b/prompt.md
@@ -93,7 +93,7 @@ If you cannot determine the exact date of a story, note "(date unconfirmed)" and
 **CRITICAL: Never create a duplicate page.** Use the `PAGE_EXISTS` result from Step 0b to decide:
 
 ### If PAGE_EXISTS = true (page for today already exists)
-Use `mcp__notion__notion-update-page` with the page ID from Step 0b to update the existing page. Replace the content with the new briefing. Update the Topics property if it changed.
+Use `mcp__notion__notion-update-page` with the page ID from Step 0b to update the existing page. Replace the content with the new briefing. Update the Topics property if it changed. Also set `icon: "📰"` so the page keeps the newspaper icon used across the database.
 
 ### If PAGE_EXISTS = false (no page for today)
 Use `mcp__notion__notion-create-pages` to create a new page **inside the AI Daily Briefing database**.
@@ -101,12 +101,13 @@ Use `mcp__notion__notion-create-pages` to create a new page **inside the AI Dail
 Use these EXACT parameters:
 - parent: {"type": "data_source_id", "data_source_id": "856794cc-d871-4a95-be2d-2a1600920a19"}
 - properties: {"Date": "[TODAY'S DATE]", "Status": "Complete", "Topics": 9}
+- icon: "📰"  (the newspaper emoji -- set this on the page so it matches every other entry in the database)
 - content: The full briefing formatted in Notion-flavored Markdown
 
 **NON-NEGOTIABLE — the page MUST live in the database, not the workspace:**
 - You MUST pass the `parent` with the `data_source_id` above on the SAME `create-pages` call that writes the content. Never call `create-pages` without `parent` — that creates an orphan workspace page that does NOT appear in the database, which is a failure.
 - The title property is named **`Date`** and its value is the bare date only, e.g. `2026-06-02` (NOT `2026-06-02 - AI Daily Briefing`, NOT empty). Existing pages use the bare date and the database view sorts on it.
-- After creating, the page's parent must be `collection://856794cc-...` (the data source). If you ever find you created a top-level/"New page" with an empty title, immediately use `mcp__notion__notion-move-pages` to move it under `data_source_id` `856794cc-d871-4a95-be2d-2a1600920a19`, then `mcp__notion__notion-update-page` to set `Date`, `Status`, and `Topics`.
+- After creating, the page's parent must be `collection://856794cc-...` (the data source). If you ever find you created a top-level/"New page" with an empty title, immediately use `mcp__notion__notion-move-pages` to move it under `data_source_id` `856794cc-d871-4a95-be2d-2a1600920a19`, then `mcp__notion__notion-update-page` to set `Date`, `Status`, `Topics`, and `icon: "📰"`.
 
 **Do NOT re-query Notion here.** Trust Step 0b's result. Re-querying risks false negatives from title format mismatches or API timing, which causes duplicate pages.
 

--- a/prompt.md
+++ b/prompt.md
@@ -96,12 +96,17 @@ If you cannot determine the exact date of a story, note "(date unconfirmed)" and
 Use `mcp__notion__notion-update-page` with the page ID from Step 0b to update the existing page. Replace the content with the new briefing. Update the Topics property if it changed.
 
 ### If PAGE_EXISTS = false (no page for today)
-Use `mcp__notion__notion-create-pages` to create a new page in the AI Daily Briefing database.
+Use `mcp__notion__notion-create-pages` to create a new page **inside the AI Daily Briefing database**.
 
 Use these EXACT parameters:
-- parent: {"data_source_id": "856794cc-d871-4a95-be2d-2a1600920a19"}
-- properties: {"Date": "[TODAY'S DATE] - AI Daily Briefing", "Status": "Complete", "Topics": 9}
+- parent: {"type": "data_source_id", "data_source_id": "856794cc-d871-4a95-be2d-2a1600920a19"}
+- properties: {"Date": "[TODAY'S DATE]", "Status": "Complete", "Topics": 9}
 - content: The full briefing formatted in Notion-flavored Markdown
+
+**NON-NEGOTIABLE — the page MUST live in the database, not the workspace:**
+- You MUST pass the `parent` with the `data_source_id` above on the SAME `create-pages` call that writes the content. Never call `create-pages` without `parent` — that creates an orphan workspace page that does NOT appear in the database, which is a failure.
+- The title property is named **`Date`** and its value is the bare date only, e.g. `2026-06-02` (NOT `2026-06-02 - AI Daily Briefing`, NOT empty). Existing pages use the bare date and the database view sorts on it.
+- After creating, the page's parent must be `collection://856794cc-...` (the data source). If you ever find you created a top-level/"New page" with an empty title, immediately use `mcp__notion__notion-move-pages` to move it under `data_source_id` `856794cc-d871-4a95-be2d-2a1600920a19`, then `mcp__notion__notion-update-page` to set `Date`, `Status`, and `Topics`.
 
 **Do NOT re-query Notion here.** Trust Step 0b's result. Re-querying risks false negatives from title format mismatches or API timing, which causes duplicate pages.
 


### PR DESCRIPTION
## Summary
Daily briefing only fired at 8 AM via launchd `StartCalendarInterval`. If the Mac was asleep at 8 AM, the run was lost for that day. This adds a self-healing, sleep/wake-aware catch-up plus a concurrency lock.

## Behavior
- **Sleep through 8 AM** → briefing runs on the **next wake the same day** (once past 08:00).
- **Mac never opened that day** → day is **skipped**, never back-filled (`--catchup` always targets the current date).
- **Already ran today** → catch-up exits immediately (no double-post), gated on `logs/YYYY-MM-DD-card.json` existing.

## Changes
- `briefing.sh`
  - `--catchup` mode: run today only if not already done **and** clock ≥ 08:00.
  - Atomic `mkdir` run lock at `logs/.briefing.lock` (auto-cleared on exit; stale lock >3h removed).
- `com.ainews.briefing.plist` (checked-in template)
  - Invoke `briefing.sh --catchup`.
  - Add `StartInterval` (1800s) — launchd fires a missed interval on the next wake, driving the same-day catch-up. Keeps the 08:00 `StartCalendarInterval` for the punctual run.
  - No secret in the template; the installed plist carries the Slack webhook in `EnvironmentVariables`.
- Docs: `README.md`, `SETUP.md`, `E2E_FLOW.md`, `LOGS.md` updated for the catch-up model, the lock artifact, and macOS webhook persistence (`~/.zshenv` + plist `EnvironmentVariables`, since launchd ignores shell profiles).

## Verification
- `bash -n briefing.sh` ✓, `plutil -lint` both plists ✓.
- Reloaded the agent and triggered via `launchctl kickstart`: catch-up logged `no briefing yet for 2026-06-02 ... running`, engine `claude` completed, Notion page created, Slack sent (HTTP 200), card/obsidian/covered-stories written, lock acquired and auto-cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)