### PR TITLE
fix(briefing): pin schedule and "today" to Pacific (PST/PDT), not host clock

### DIFF
--- a/briefing.sh
+++ b/briefing.sh
@@ -47,13 +47,15 @@ Options:
   --cli, -c ENGINE   AI engine: claude, codex, gemini, copilot
   --date, -d DATE    Briefing date (YYYY-MM-DD), default: today
   --catchup          Scheduled mode: run today only if not already done and
-                     it's at/after 08:00 (skips if asleep through 8am until
-                     next wake same day; never back-fills missed days)
+                     it's at/after 08:00 Pacific (skips if asleep through 8am
+                     until next wake same Pacific day; never back-fills)
   --help, -h         Show this help
 
 Environment:
   AI_BRIEFING_CLI    Default engine (overridden by --cli)
   AI_BRIEFING_MODEL  Model name (default: opus for claude)
+  AI_BRIEFING_TZ     Timezone for "today" and the 08:00 schedule
+                     (default: America/Los_Angeles)
 USAGE
       exit 0 ;;
     -*)
@@ -63,9 +65,17 @@ USAGE
   esac
 done
 
-DATE="${DATE_ARG:-$(date +%Y-%m-%d)}"
-TODAY=$(date +%Y-%m-%d)
-TIME=$(date +%H:%M:%S)
+# Briefing timezone -----------------------------------------------------------
+# The notion of "today" and the 08:00 schedule follow Pacific time (PST/PDT) no
+# matter what the host machine's clock or timezone is set to. launchd has no
+# timezone field for StartCalendarInterval (it uses the host's local TZ), so the
+# real time pinning lives here in the script and the plist just polls often.
+# Override with AI_BRIEFING_TZ (e.g. America/New_York) for a different zone.
+BRIEF_TZ="${AI_BRIEFING_TZ:-America/Los_Angeles}"
+
+DATE="${DATE_ARG:-$(TZ="$BRIEF_TZ" date +%Y-%m-%d)}"
+TODAY=$(TZ="$BRIEF_TZ" date +%Y-%m-%d)
+TIME=$(TZ="$BRIEF_TZ" date +%H:%M:%S)
 LOG_FILE="$LOG_DIR/$DATE.log"
 
 # Prevent nested Claude Code sessions
@@ -75,24 +85,25 @@ mkdir -p "$LOG_DIR"
 
 # -- Logging ---------------------------------------------------
 write_log() {
-  echo "[$DATE $(date +%H:%M:%S)] $1" >> "$LOG_FILE"
+  echo "[$DATE $(TZ="$BRIEF_TZ" date +%H:%M:%S)] $1" >> "$LOG_FILE"
 }
 
 # -- Catch-up guard (scheduled --catchup runs only) ------------
-# Goal: 8am run when awake; if asleep at 8am, run on the next wake THAT day;
-# if the machine isn't opened until a later day, treat the missed day as gone
-# (the run always targets the current date, so it never back-fills).
+# All times below are Pacific (BRIEF_TZ), not the host clock.
+# Goal: 08:00 Pacific run when awake; if asleep at 08:00, run on the next wake
+# THAT Pacific day; if the machine isn't opened until a later day, treat the
+# missed day as gone (the run targets the current Pacific date, never back-fills).
 if [[ "$CATCHUP" == "true" ]]; then
   if [ -f "$LOG_DIR/$DATE-card.json" ]; then
     write_log "Catch-up: briefing for $DATE already done; skipping."
     exit 0
   fi
-  HHMM=$(date +%H%M)
+  HHMM=$(TZ="$BRIEF_TZ" date +%H%M)
   if (( 10#$HHMM < 800 )); then
-    write_log "Catch-up: before 08:00 (now $HHMM); deferring to the scheduled run."
+    write_log "Catch-up: before 08:00 $BRIEF_TZ (now $HHMM); deferring to the scheduled run."
     exit 0
   fi
-  write_log "Catch-up: no briefing yet for $DATE and now is $HHMM; running."
+  write_log "Catch-up: no briefing yet for $DATE and now is $HHMM $BRIEF_TZ; running."
 fi
 
 # -- Single-run lock -------------------------------------------

--- a/com.ainews.briefing.plist
+++ b/com.ainews.briefing.plist
@@ -26,14 +26,35 @@
         <string>--catchup</string>
     </array>
 
-    <!-- Punctual 8am run when the machine is awake. -->
+    <!-- Punctual 08:00 PACIFIC run when the machine is awake.
+         launchd's StartCalendarInterval has no timezone field; it fires in the
+         HOST's local zone. briefing.sh pins the briefing's notion of "today"
+         and its 08:00 gate to AI_BRIEFING_TZ (default America/Los_Angeles), so
+         set the host times below to whatever maps to 08:00 in that zone on THIS
+         machine. The author's host is Asia/Ho_Chi_Minh (+07, no DST), where
+         08:00 Pacific is two host times across the year:
+           - 22:00 +07  == 08:00 PDT (summer, UTC-7)
+           - 23:00 +07  == 08:00 PST (winter, UTC-8)
+         Both fire daily; the Pacific guard runs only the one at/after 08:00
+         Pacific and skips the other (it lands at 07:00 Pacific, before the
+         gate). If your host clock IS the target zone, a single 08:00 entry is
+         fine. The 1800s StartInterval below is the wake / catch-up safety net so
+         a missed fire still runs within ~30 min. -->
     <key>StartCalendarInterval</key>
-    <dict>
-        <key>Hour</key>
-        <integer>8</integer>
-        <key>Minute</key>
-        <integer>0</integer>
-    </dict>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>22</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>23</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
 
     <!-- Catch-up: launchd fires a missed interval on the next wake. With
          --catchup the script runs today only if not already done and it's
@@ -56,6 +77,8 @@
         <string>/Users/davidnguyen</string>
         <key>AI_BRIEFING_MODEL</key>
         <string>claude-sonnet-4-6</string>
+        <key>AI_BRIEFING_TZ</key>
+        <string>America/Los_Angeles</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

The launchd agent fired `StartCalendarInterval` at **08:00 in the host's local timezone** (this machine is `Asia/Ho_Chi_Minh`, +07). That is **18:00 PDT the previous day**, so the daily briefing ran hours off-target and could key to the wrong calendar day. launchd has no timezone field for `StartCalendarInterval` (it always uses the host zone), so the fix must live in the script.

## Changes

**`briefing.sh`**
- New `AI_BRIEFING_TZ` (default `America/Los_Angeles`). The briefing's notion of "today", the `08:00` catch-up gate, and `write_log` timestamps now resolve in this zone via `TZ=`. PST/PDT is applied automatically — DST-proof, host-TZ-independent.

**`com.ainews.briefing.plist`**
- `StartCalendarInterval` is now an array firing at **22:00 and 23:00 +07** = **08:00 PDT and 08:00 PST**. The Pacific guard runs only the entry at/after 08:00 Pacific and skips the other (it lands at 07:00 Pacific, before the gate), so exactly one run/day in either DST season.
- `StartInterval` (1800s) unchanged — wake / catch-up safety net.
- Added `AI_BRIEFING_TZ=America/Los_Angeles` to the agent environment.

## Behavior

| | Before | After |
|---|---|---|
| Daily fire | 08:00 +07 (= 18:00 PDT prev day) | 08:00 Pacific, every season |
| "Today" date | host calendar day | Pacific calendar day |
| DST | n/a | handled by `TZ=` |

## Notes
- The installed copy at `~/Library/LaunchAgents/` (which holds a Slack webhook secret) is updated out-of-band and intentionally not in this repo.
- `scripts/update-schedule.sh` still assumes a single `StartCalendarInterval` dict; its `sed` now only touches the first array entry. Out of scope here — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)