### PR TITLE
feat(briefing): 8 AM Pacific parity on Windows + AI_BRIEFING_TZ docs & macOS setter

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,8 +82,8 @@ The system is composed of five primary layers: a platform-native scheduler, a sc
 ```mermaid
 graph TD
     subgraph "Platform Schedulers"
-        A1[macOS launchd] -->|8:00 AM daily| B1[briefing.sh]
-        A2[Windows Task Scheduler] -->|8:00 AM daily| B2[briefing.ps1]
+        A1[macOS launchd] -->|8 AM Pacific daily| B1[briefing.sh]
+        A2[Windows Task Scheduler] -->|8 AM Pacific daily| B2[briefing.ps1]
     end
 
     subgraph "Engine Selection"
@@ -1743,6 +1743,10 @@ Edit `prompt.md`, Section "Topics to Search". Update the `Topics` property value
 ### Changing the AI Model
 
 Set the `AI_BRIEFING_MODEL` environment variable, or change the `--model` argument in the Claude entry script for your platform (current default: `opus`).
+
+### Changing the Timezone
+
+The briefing's "today" and its 08:00 schedule follow `AI_BRIEFING_TZ`. The scheduler (launchd / Task Scheduler) fires in the host's local time and has no timezone field, so the entry scripts poll frequently and gate the run to 08:00 in `AI_BRIEFING_TZ`. Default is Pacific (`America/Los_Angeles` on *nix, `Pacific Standard Time` on Windows); DST is applied automatically. Override with any IANA zone (`*nix`, or PowerShell 7+) or Windows zone id (Windows PowerShell 5.1).
 
 ### Multi-Engine Support
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ flowchart TD
         A2[Windows Task Scheduler]
     end
 
-    A1 -->|8:00 AM daily| B1[briefing.sh]
-    A2 -->|8:00 AM daily| B2[briefing.ps1]
+    A1 -->|8 AM Pacific daily| B1[briefing.sh]
+    A2 -->|8 AM Pacific daily| B2[briefing.ps1]
 
     B1 -->|Reads| C[prompt.md]
     B2 -->|Reads| C
@@ -201,7 +201,7 @@ cd $env:USERPROFILE\ai-news-briefing
 .\install-task.ps1
 ```
 
-This registers a Task Scheduler task named `AiNewsBriefing` that runs daily at 8:00 AM under the current user account.
+This registers a Task Scheduler task named `AiNewsBriefing` that runs daily at **8:00 AM Pacific** (PST/PDT) under the current user account. Task Scheduler triggers fire in the host's local time and have no timezone field, so the task repeats every 30 minutes and `briefing.ps1 -Catchup` gates the run to 08:00 in `AI_BRIEFING_TZ` (default Pacific) -- so it lands at 8 AM Pacific no matter what zone the machine is set to. See [Change the timezone](#change-the-timezone).
 
 To customize the time:
 
@@ -215,20 +215,44 @@ To customize the time:
 
 ### Change the schedule
 
-**macOS:** Edit `com.ainews.briefing.plist` and modify the `StartCalendarInterval` section (the daily run time), then reload:
+The briefing fires at **8:00 AM Pacific (PST/PDT)** by default, regardless of the host machine's clock or timezone. Neither launchd nor Task Scheduler has a timezone field, so the time is pinned inside the entry script: it polls frequently and `--catchup` / `-Catchup` only runs once the clock passes 08:00 in `AI_BRIEFING_TZ`. To run in a different zone, see [Change the timezone](#change-the-timezone); to change the *hour*, adjust the trigger and the `08:00` gate as below.
+
+**macOS:** Edit `com.ainews.briefing.plist` and modify the `StartCalendarInterval` entries, then reload:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.ainews.briefing.plist
 launchctl load ~/Library/LaunchAgents/com.ainews.briefing.plist
 ```
 
-The plist also carries a `StartInterval` (every 30 min) that drives the sleep/wake **catch-up** -- it runs `briefing.sh --catchup`, which only acts when today's briefing hasn't run yet and it's past 08:00. Leave it in place; it is what recovers a run missed because the Mac was asleep at 8 AM. To change the catch-up cadence, edit the `StartInterval` integer (seconds).
+> The `StartCalendarInterval` is an array of host-local times that map to 08:00 Pacific (e.g. on a UTC+7 host, `22:00` = 8 AM PDT and `23:00` = 8 AM PST). Both fire; the Pacific guard runs only the one at/after 08:00 Pacific. The `StartInterval` (every 30 min) is the sleep/wake **catch-up** -- it runs `briefing.sh --catchup`, which only acts when today's briefing hasn't run yet and it's past 08:00 Pacific. Leave it in place; it recovers a run missed because the Mac was asleep at 8 AM.
 
-**Windows:** Re-run the installer with new time parameters:
+**Windows:** Re-run the installer with a new host-local anchor time (the 30-min poll + Pacific guard still apply):
 
 ```powershell
 .\install-task.ps1 -Hour 9 -Minute 0
 ```
+
+### Change the timezone
+
+The briefing's notion of "today" and its 08:00 schedule both follow `AI_BRIEFING_TZ`. The default is Pacific. Set it to any zone -- DST is handled automatically.
+
+```bash
+# macOS / Linux -- use an IANA zone id
+export AI_BRIEFING_TZ=America/New_York
+```
+
+```powershell
+# Windows -- use a Windows zone id ("Eastern Standard Time" covers EST/EDT)
+setx AI_BRIEFING_TZ "Eastern Standard Time"
+```
+
+On macOS the scheduled job reads it from the plist's `EnvironmentVariables`. Set it in one step (edits the installed plist in place and reloads):
+
+```bash
+./scripts/update-schedule.sh --tz America/New_York
+```
+
+Or add/edit the `AI_BRIEFING_TZ` key in `com.ainews.briefing.plist` by hand and reload. On Windows, `setx` persists it to your user environment and `briefing.ps1` picks it up on the next run. (PowerShell 7+ also accepts IANA ids like `America/New_York`; Windows PowerShell 5.1 requires the Windows id.)
 
 ### Change the AI engine
 
@@ -279,7 +303,7 @@ Edit `prompt.md` and modify the "Topics to Search" list. You can add, remove, or
 
 ### Automatic (scheduled)
 
-Once installed, the briefing runs automatically every day at the scheduled time (default: 8:00 AM). No action needed.
+Once installed, the briefing runs automatically every day at the scheduled time (default: 8:00 AM Pacific, PST/PDT). No action needed.
 
 ### Manual trigger
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -198,13 +198,22 @@ launchctl load ~/Library/LaunchAgents/com.ainews.briefing.plist
 launchctl list | grep ainews
 ```
 
-**Scheduling model.** The plist runs `briefing.sh --catchup` and registers two triggers:
-- `StartCalendarInterval` (08:00) — the punctual daily run when the Mac is awake.
+**Scheduling model.** The briefing fires at **08:00 Pacific (PST/PDT)** regardless of the
+host's timezone. launchd's `StartCalendarInterval` has no timezone field (it uses the host
+clock), so the time is pinned inside `briefing.sh` via `AI_BRIEFING_TZ` (default
+`America/Los_Angeles`) and the plist just polls. The plist runs `briefing.sh --catchup`
+and registers two triggers:
+- `StartCalendarInterval` — an array of host-local times that map to 08:00 Pacific. On a
+  UTC+7 host that is `22:00` (= 8 AM PDT) and `23:00` (= 8 AM PST); both fire daily and the
+  Pacific guard runs only the one at/after 08:00 Pacific. Adjust these for your host's zone.
 - `StartInterval` (1800s) — the **catch-up**. launchd fires a missed interval on the
   next wake; with `--catchup` the script runs today's briefing only if it hasn't run
-  yet (`logs/YYYY-MM-DD-card.json` is absent) and the clock is at/after 08:00.
+  yet (`logs/YYYY-MM-DD-card.json` is absent) and the clock is at/after 08:00 Pacific.
 
-Net effect: asleep through 8 AM → the briefing runs on the next wake **the same day**;
+To run in a zone other than Pacific, edit the `AI_BRIEFING_TZ` key in the plist's
+`EnvironmentVariables` (any IANA zone id) and reload.
+
+Net effect: asleep through 8 AM Pacific → the briefing runs on the next wake **the same day**;
 a day the Mac never opens is skipped (no back-fill); already-ran days never double-post.
 A `logs/.briefing.lock` directory guards against overlapping fires and is auto-cleared
 (including a stale lock older than 3h from a crashed run).
@@ -219,9 +228,14 @@ A `logs/.briefing.lock` directory guards against overlapping fires and is auto-c
 ### Windows (Task Scheduler)
 
 ```powershell
-.\install-task.ps1              # Default: 8:00 AM
-.\install-task.ps1 -Hour 7 -Minute 30  # Custom time
+.\install-task.ps1              # Default: 8:00 AM Pacific (PST/PDT)
+.\install-task.ps1 -Hour 7 -Minute 30  # Custom host-local anchor time
 ```
+
+Like macOS, the Windows task polls every 30 minutes and `briefing.ps1 -Catchup` gates the
+run to 08:00 in `AI_BRIEFING_TZ` (default `Pacific Standard Time`), so it lands at 8 AM
+Pacific on any host zone. Change the zone with `setx AI_BRIEFING_TZ "Eastern Standard Time"`
+(Windows zone id; PowerShell 7+ also accepts IANA ids like `America/New_York`).
 
 ### Change schedule
 

--- a/briefing.ps1
+++ b/briefing.ps1
@@ -11,6 +11,13 @@
 .PARAMETER Cli
     AI engine to use: claude, codex, gemini, copilot.
     If omitted, reads AI_BRIEFING_CLI env var; if unset, tries each in order.
+.PARAMETER Catchup
+    Scheduled mode: run today only if not already done and it is at/after 08:00
+    in AI_BRIEFING_TZ (default Pacific). Lets a frequently-repeating task post
+    exactly once per Pacific day. Never back-fills missed days.
+.NOTES
+    AI_BRIEFING_TZ controls the briefing's "today" and the 08:00 schedule
+    (default "Pacific Standard Time"; PST/PDT handled automatically).
 .EXAMPLE
     .\briefing.ps1
 .EXAMPLE
@@ -22,7 +29,8 @@
 param(
     [string]$BriefingDate = "",
     [ValidateSet("claude", "codex", "gemini", "copilot", "")]
-    [string]$Cli = ""
+    [string]$Cli = "",
+    [switch]$Catchup
 )
 
 Set-StrictMode -Version Latest
@@ -30,17 +38,34 @@ $ErrorActionPreference = "Continue"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $LogDir = Join-Path $ScriptDir "logs"
-$Date = if ($BriefingDate) { $BriefingDate } else { Get-Date -Format "yyyy-MM-dd" }
-$LogFile = Join-Path $LogDir "$Date.log"
 
 # Prevent nested Claude Code sessions
 $env:CLAUDECODE = $null
 
-# Refresh persistent env vars from registry
-foreach ($name in @("AI_BRIEFING_TEAMS_WEBHOOK", "AI_BRIEFING_SLACK_WEBHOOK", "AI_BRIEFING_CLI", "AI_BRIEFING_MODEL")) {
+# Refresh persistent env vars from registry (User scope -> Process scope)
+foreach ($name in @("AI_BRIEFING_TEAMS_WEBHOOK", "AI_BRIEFING_SLACK_WEBHOOK", "AI_BRIEFING_CLI", "AI_BRIEFING_MODEL", "AI_BRIEFING_TZ")) {
     $val = [Environment]::GetEnvironmentVariable($name, "User")
     if ($val) { [Environment]::SetEnvironmentVariable($name, $val, "Process") }
 }
+
+# -- Briefing timezone -----------------------------------------
+# The notion of "today" and the 08:00 schedule follow this timezone (default
+# Pacific) regardless of the host machine's clock. Use a Windows zone id --
+# "Pacific Standard Time" already covers PST/PDT (DST handled automatically).
+# On PowerShell 7+ an IANA id such as "America/Los_Angeles" also resolves.
+# Override with AI_BRIEFING_TZ.
+$BriefTz = if ($env:AI_BRIEFING_TZ) { $env:AI_BRIEFING_TZ } else { "Pacific Standard Time" }
+function Get-BriefNow {
+    try {
+        $tz = [System.TimeZoneInfo]::FindSystemTimeZoneById($BriefTz)
+        return [System.TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow, $tz)
+    } catch {
+        return (Get-Date)  # unknown id (e.g. an IANA name on PS 5.1) -> host local
+    }
+}
+$BriefNow = Get-BriefNow
+$Date = if ($BriefingDate) { $BriefingDate } else { $BriefNow.ToString("yyyy-MM-dd") }
+$LogFile = Join-Path $LogDir "$Date.log"
 
 if (-not (Test-Path $LogDir)) {
     New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
@@ -49,8 +74,27 @@ if (-not (Test-Path $LogDir)) {
 # -- Logging ---------------------------------------------------
 function Write-Log {
     param([string]$Message)
-    $ts = Get-Date -Format "HH:mm:ss"
+    $ts = (Get-BriefNow).ToString("HH:mm:ss")
     "$Date $ts $Message" | Out-File -FilePath $LogFile -Append -Encoding utf8
+}
+
+# -- Catch-up guard (scheduled -Catchup runs only) -------------
+# All times are in BriefTz (Pacific by default), not the host clock. Run today
+# only if not already done and it is at/after 08:00; before then, defer to a
+# later repetition. Mirrors the macOS/launchd catch-up behavior so the task can
+# poll often and still post exactly once per Pacific day.
+if ($Catchup) {
+    $cardPath = Join-Path $LogDir "$Date-card.json"
+    if (Test-Path $cardPath) {
+        Write-Log "Catch-up: briefing for $Date already done; skipping."
+        exit 0
+    }
+    $hhmm = [int]((Get-BriefNow).ToString("HHmm"))
+    if ($hhmm -lt 800) {
+        Write-Log "Catch-up: before 08:00 $BriefTz (now $hhmm); deferring to a later run."
+        exit 0
+    }
+    Write-Log "Catch-up: no briefing yet for $Date and now is $hhmm $BriefTz; running."
 }
 
 Write-Log "Starting AI News Briefing..."
@@ -126,7 +170,7 @@ if (-not (Test-Path $PromptFile)) {
 
 $Prompt = Get-Content -Path $PromptFile -Raw
 
-$today = Get-Date -Format "yyyy-MM-dd"
+$today = $BriefNow.ToString("yyyy-MM-dd")
 if ($Date -ne $today) {
     $datePrefix = @"
 BRIEFING DATE OVERRIDE: $Date

--- a/index.html
+++ b/index.html
@@ -268,8 +268,8 @@ flowchart LR
         A2["Windows Task Scheduler"]
         A3["Manual / make run"]
     end
-    A1 --> B["briefing.sh / .ps1"]
-    A2 --> B
+    A1 -->|8 AM Pacific| B["briefing.sh / .ps1"]
+    A2 -->|8 AM Pacific| B
     A3 --> B
     B --> C["prompt.md"]
     C --> D["AI Engine (Claude/Codex/Gemini/Copilot)"]
@@ -301,8 +301,8 @@ flowchart TD
         A3["Manual make run"]
     end
 
-    A1 --> B1["briefing.sh"]
-    A2 --> B2["briefing.ps1"]
+    A1 -->|8 AM Pacific| B1["briefing.sh"]
+    A2 -->|8 AM Pacific| B2["briefing.ps1"]
     A3 --> B1
     A3 --> B2
 
@@ -429,7 +429,7 @@ sequenceDiagram
         </tr>
       </thead>
       <tbody>
-        <tr><td>Trigger</td><td>08:00 schedule or manual command</td><td>Script execution starts</td><td><code>com.ainews.briefing.plist</code>, <code>install-task.ps1</code>, <code>Makefile</code></td></tr>
+        <tr><td>Trigger</td><td>08:00 Pacific (PST/PDT) schedule or manual command</td><td>Script execution starts</td><td><code>com.ainews.briefing.plist</code>, <code>install-task.ps1</code>, <code>Makefile</code></td></tr>
         <tr><td>Bootstrap</td><td>Date + environment</td><td>Prompt text + runtime context</td><td><code>briefing.sh</code>, <code>briefing.ps1</code></td></tr>
         <tr><td>Dedup</td><td><code>logs/covered-stories.txt</code> + latest Notion page</td><td>Exclusion list for this run</td><td>Step 0a (file) + Step 0b (Notion MCP)</td></tr>
         <tr><td>AI Run</td><td><code>prompt.md</code></td><td>Notion briefing + card.json + obsidian.md + covered-stories update</td><td>AI engine (Claude/Codex/Gemini/Copilot), WebSearch, Notion MCP</td></tr>
@@ -664,7 +664,7 @@ flowchart TD
       </tr>
       </thead>
       <tbody>
-      <tr><td>Trigger</td><td>Scheduled (8:00 AM daily)</td><td>On-demand</td></tr>
+      <tr><td>Trigger</td><td>Scheduled (8:00 AM Pacific / PST/PDT, daily)</td><td>On-demand</td></tr>
       <tr><td>Scope</td><td>9 fixed AI topics</td><td>Any user-defined topic</td></tr>
       <tr><td>Depth</td><td>Broad scan (search per topic)</td><td>Deep (5 parallel agents + follow-ups)</td></tr>
       <tr><td>Deduplication</td><td>Yes (covered-stories.txt)</td><td>No (standalone)</td></tr>
@@ -898,7 +898,7 @@ graph TD
       <tr><td><code>export-logs</code></td><td>Archive logs to tar.gz/zip</td><td><code>bash scripts/export-logs.sh --from 2026-03-01 --to 2026-03-09</code></td></tr>
       <tr><td><code>backup-prompt</code></td><td>Version and restore prompt.md</td><td><code>bash scripts/backup-prompt.sh --list</code></td></tr>
       <tr><td><code>topic-edit</code></td><td>Add/remove/list topics in prompt.md</td><td><code>bash scripts/topic-edit.sh --list</code></td></tr>
-      <tr><td><code>update-schedule</code></td><td>Adjust scheduler time</td><td><code>bash scripts/update-schedule.sh --hour 7 --minute 30</code></td></tr>
+      <tr><td><code>update-schedule</code></td><td>Adjust scheduler anchor time or timezone</td><td><code>bash scripts/update-schedule.sh 7 30</code> · <code>--tz America/New_York</code></td></tr>
       <tr><td><code>notify</code></td><td>Native OS status notification</td><td><code>bash scripts/notify.sh</code></td></tr>
       <tr><td><code>notify-teams</code></td><td>Validate and POST Adaptive Card JSON to Teams webhook(s)</td><td><code>bash scripts/notify-teams.sh --all --card-file logs/2026-03-24-card.json</code></td></tr>
       <tr><td><code>notify-slack</code></td><td>Convert Teams card JSON to Block Kit and POST to Slack webhook(s)</td><td><code>bash scripts/notify-slack.sh --all --card-file logs/2026-03-24-card.json</code></td></tr>
@@ -976,6 +976,36 @@ flowchart LR
 <span class="comment"># Explicit card file for replay/testing</span>
 <span class="cmd">.\scripts\notify-teams.ps1</span> <span class="flag">-All -CardFile</span> <span class="string">".\logs\2026-03-24-card.json"</span>
 <span class="cmd">.\scripts\notify-slack.ps1</span> <span class="flag">-All -CardFile</span> <span class="string">".\logs\2026-03-24-card.json"</span></pre>
+    </div>
+  </div>
+  <div class="code-section" style="max-width: 780px; margin: 0 auto 1.25rem;">
+    <div class="code-header">
+      <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+      <span class="code-title">configure timezone (macOS/Linux)</span>
+      <button class="code-copy">Copy</button>
+    </div>
+    <div class="code-body">
+<pre><span class="comment"># Briefing fires at 08:00 in AI_BRIEFING_TZ (default America/Los_Angeles),</span>
+<span class="comment"># regardless of the host clock. DST (PST/PDT) is handled automatically.</span>
+<span class="comment"># Set the zone for the installed launchd agent in one step (edits plist + reloads):</span>
+<span class="cmd">bash</span> scripts/update-schedule.sh <span class="flag">--tz</span> America/New_York
+<span class="comment"># Move only the host-local punctual anchor (30-min poll + guard still apply):</span>
+<span class="cmd">bash</span> scripts/update-schedule.sh 7 30
+<span class="comment"># For manual/foreground runs, export it for the process:</span>
+<span class="cmd">export</span> AI_BRIEFING_TZ=<span class="string">"America/Los_Angeles"</span></pre>
+    </div>
+  </div>
+  <div class="code-section" style="max-width: 780px; margin: 0 auto 1.25rem;">
+    <div class="code-header">
+      <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+      <span class="code-title">configure timezone (Windows PowerShell)</span>
+      <button class="code-copy">Copy</button>
+    </div>
+    <div class="code-body">
+<pre><span class="comment"># Use a Windows zone id ("Pacific Standard Time" covers PST/PDT;</span>
+<span class="comment"># PowerShell 7+ also accepts IANA ids like "America/New_York").</span>
+[Environment]::SetEnvironmentVariable(<span class="string">"AI_BRIEFING_TZ"</span>, <span class="string">"Eastern Standard Time"</span>, <span class="string">"User"</span>)
+<span class="comment"># briefing.ps1 refreshes it from the registry on the next scheduled run.</span></pre>
     </div>
   </div>
   <div class="code-section" style="max-width: 780px; margin: 0 auto 1.25rem;">

--- a/install-task.ps1
+++ b/install-task.ps1
@@ -3,7 +3,12 @@
 .SYNOPSIS
     Registers (or re-registers) the AI News Briefing scheduled task.
 .DESCRIPTION
-    Creates a Windows Task Scheduler task that runs briefing.ps1 daily at 8:00 AM.
+    Creates a Windows Task Scheduler task that runs briefing.ps1 at 8:00 AM
+    Pacific (PST/PDT). Task Scheduler triggers fire in the HOST's local time and
+    have no timezone field, so the task instead repeats every 30 minutes and
+    briefing.ps1 -Catchup gates the actual run to 08:00 in AI_BRIEFING_TZ
+    (default Pacific). This makes the run land at 08:00 Pacific on any host TZ.
+    The -Hour/-Minute below add a punctual host-local anchor on top of the poll.
     Run this script from an elevated (admin) PowerShell prompt OR as your own user
     (the task will run under your account).
 .EXAMPLE
@@ -35,27 +40,38 @@ if ($existing) {
 
 $action = New-ScheduledTaskAction `
     -Execute "powershell.exe" `
-    -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$BriefingScript`"" `
+    -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$BriefingScript`" -Catchup" `
     -WorkingDirectory $ScriptDir
 
-$trigger = New-ScheduledTaskTrigger -Daily -At ("{0:D2}:{1:D2}" -f $Hour, $Minute)
+# Two triggers, both running briefing.ps1 -Catchup (which gates to 08:00 Pacific):
+#   1. A punctual daily anchor at the host-local -Hour:-Minute.
+#   2. A 30-minute poll that repeats all day, so the run still lands within
+#      ~30 min of 08:00 Pacific even when the host clock is in another zone or
+#      the machine was asleep at the anchor time. The catch-up guard ensures
+#      exactly one briefing per Pacific day regardless of how often it fires.
+$dailyTrigger = New-ScheduledTaskTrigger -Daily -At ("{0:D2}:{1:D2}" -f $Hour, $Minute)
+$pollTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).Date `
+    -RepetitionInterval (New-TimeSpan -Minutes 30) `
+    -RepetitionDuration ([TimeSpan]::MaxValue)
 
 $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries `
     -DontStopIfGoingOnBatteries `
     -StartWhenAvailable `
+    -MultipleInstances IgnoreNew `
     -ExecutionTimeLimit (New-TimeSpan -Minutes 30)
 
 Register-ScheduledTask `
     -TaskName $TaskName `
     -Action $action `
-    -Trigger $trigger `
+    -Trigger @($dailyTrigger, $pollTrigger) `
     -Settings $settings `
-    -Description "Daily AI news briefing via Claude Code CLI" `
+    -Description "Daily AI news briefing (08:00 Pacific via -Catchup) using Claude Code CLI" `
     -RunLevel Limited
 
 Write-Host ""
-Write-Host "Task '$TaskName' registered to run daily at $("{0:D2}:{1:D2}" -f $Hour, $Minute)."
+Write-Host "Task '$TaskName' registered: 08:00 Pacific via -Catchup (host-local anchor $("{0:D2}:{1:D2}" -f $Hour, $Minute) + 30-min poll)."
+Write-Host "Set a different zone with: setx AI_BRIEFING_TZ `"Eastern Standard Time`""
 Write-Host ""
 Write-Host "Useful commands:"
 Write-Host "  Run now:    schtasks /run /tn $TaskName"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1232,6 +1232,7 @@ Scripts read configuration from environment variables. None are required at run-
 |---|---|---|---|
 | `AI_BRIEFING_CLI` | `briefing.sh`, `custom-brief.sh` | auto-detect via fallback chain | Force a specific engine (`claude` / `codex` / `gemini` / `copilot`) |
 | `AI_BRIEFING_MODEL` | `briefing.sh`, `custom-brief.sh` | engine-specific | Override the model passed to the selected engine |
+| `AI_BRIEFING_TZ` | `briefing.sh` / `.ps1` | `America/Los_Angeles` (`Pacific Standard Time` on Windows) | Timezone for the briefing's "today" and the 08:00 schedule. DST handled automatically. *nix uses IANA ids; Windows uses Windows zone ids (PS 7+ also accepts IANA). |
 | `AI_BRIEFING_TEAMS_WEBHOOK` | `notify-teams.sh` / `.ps1` | unset | Teams Incoming Webhook URL (or `;`-separated list) |
 | `AI_BRIEFING_SLACK_WEBHOOK` | `notify-slack.sh` / `.ps1` | unset | Slack Incoming Webhook URL (or `;`-separated list) |
 | `AI_BRIEFING_OBSIDIAN_VAULT` | `briefing.sh`, `publish-obsidian.sh` / `.ps1`, `test-obsidian.sh` / `.ps1`, `topic-stats.sh` | unset | Absolute path to the Obsidian vault root. When unset, Obsidian publishing is skipped. |

--- a/scripts/update-schedule.sh
+++ b/scripts/update-schedule.sh
@@ -1,67 +1,104 @@
 #!/bin/bash
 set -euo pipefail
 
-# update-schedule.sh — Change the daily briefing schedule time (macOS only).
-# Updates the plist and reloads the launchd agent.
-# Usage: ./scripts/update-schedule.sh HH MM
-# Example: ./scripts/update-schedule.sh 07 30   # Set to 7:30 AM
+# update-schedule.sh — Change the daily briefing schedule on macOS.
+#
+# Edits the INSTALLED launchd plist in place with PlistBuddy (so webhook secrets
+# and other keys are preserved) and reloads the agent.
+#
+# Usage:
+#   ./scripts/update-schedule.sh HOUR [MINUTE]        # set host-local anchor time
+#   ./scripts/update-schedule.sh --tz ZONE            # set the briefing timezone
+#   ./scripts/update-schedule.sh --tz ZONE HOUR [MIN] # both
+#
+# Examples:
+#   ./scripts/update-schedule.sh 7 30                 # anchor at 07:30 host-local
+#   ./scripts/update-schedule.sh --tz America/New_York
+#   ./scripts/update-schedule.sh --tz Europe/London 9
+#
+# The briefing fires at 08:00 in AI_BRIEFING_TZ (default America/Los_Angeles)
+# regardless of the host clock; the 30-min poll + Pacific guard in briefing.sh
+# do the real pinning. HOUR/MINUTE only move the punctual host-local anchor
+# (the first StartCalendarInterval entry). --tz changes the zone the 08:00 gate
+# and the briefing's "today" are evaluated in.
 
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PLIST_SRC="$SCRIPT_DIR/com.ainews.briefing.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.ainews.briefing.plist"
 LABEL="com.ainews.briefing"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+PB="/usr/libexec/PlistBuddy"
 
 if [ "$(uname -s)" != "Darwin" ]; then
-    echo "This script is for macOS only."
-    echo "On Windows, use: .\\install-task.ps1 -Hour HH -Minute MM"
+    echo "This script is for macOS only." >&2
+    echo "On Windows, set the zone with: setx AI_BRIEFING_TZ \"Eastern Standard Time\"" >&2
+    echo "and the time with: .\\install-task.ps1 -Hour HH -Minute MM" >&2
     exit 1
 fi
+[ -f "$PLIST" ] || { echo "ERROR: $PLIST not found. Run 'make install' first." >&2; exit 1; }
+[ -x "$PB" ]    || { echo "ERROR: PlistBuddy not found at $PB." >&2; exit 1; }
 
-if [ $# -lt 2 ]; then
-    echo "Usage: update-schedule.sh HOUR MINUTE"
-    echo "Example: update-schedule.sh 7 30  (sets schedule to 7:30 AM)"
-    exit 1
-fi
+TZ_ARG=""
+HOUR=""
+MINUTE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tz)
+            [[ $# -lt 2 ]] && { echo "ERROR: --tz requires a zone (e.g. America/New_York)" >&2; exit 1; }
+            TZ_ARG="$2"; shift 2 ;;
+        -*)
+            echo "Unknown option: $1" >&2; exit 1 ;;
+        *)
+            if   [ -z "$HOUR" ];   then HOUR="$1"
+            elif [ -z "$MINUTE" ]; then MINUTE="$1"
+            else echo "Unexpected argument: $1" >&2; exit 1
+            fi
+            shift ;;
+    esac
+done
 
-HOUR="$1"
-MINUTE="$2"
-
-# Validate
-if ! [[ "$HOUR" =~ ^[0-9]+$ ]] || [ "$HOUR" -lt 0 ] || [ "$HOUR" -gt 23 ]; then
-    echo "Invalid hour: $HOUR (must be 0-23)"
-    exit 1
-fi
-if ! [[ "$MINUTE" =~ ^[0-9]+$ ]] || [ "$MINUTE" -lt 0 ] || [ "$MINUTE" -gt 59 ]; then
-    echo "Invalid minute: $MINUTE (must be 0-59)"
+if [ -z "$TZ_ARG" ] && [ -z "$HOUR" ]; then
+    echo "Usage: update-schedule.sh [HOUR [MINUTE]] [--tz ZONE]" >&2
+    echo "  update-schedule.sh 7 30                 # host-local anchor 07:30" >&2
+    echo "  update-schedule.sh --tz America/New_York" >&2
     exit 1
 fi
 
 echo ""
-echo "  Updating schedule to $(printf '%02d:%02d' "$HOUR" "$MINUTE")..."
 
-# Update the plist source file
-# Replace the Hour and Minute values in StartCalendarInterval
-sed -i.bak -E "
-    /StartCalendarInterval/,/<\/dict>/ {
-        /<key>Hour<\/key>/{
-            n; s/<integer>[0-9]+<\/integer>/<integer>$HOUR<\/integer>/
-        }
-        /<key>Minute<\/key>/{
-            n; s/<integer>[0-9]+<\/integer>/<integer>$MINUTE<\/integer>/
-        }
-    }
-" "$PLIST_SRC"
-rm -f "${PLIST_SRC}.bak"
+# -- Timezone --------------------------------------------------
+if [ -n "$TZ_ARG" ]; then
+    # Sanity-check the zone resolves on this host.
+    if ! TZ="$TZ_ARG" date >/dev/null 2>&1; then
+        echo "  WARNING: '$TZ_ARG' may not be a valid IANA zone on this host." >&2
+    fi
+    "$PB" -c "Set :EnvironmentVariables:AI_BRIEFING_TZ $TZ_ARG" "$PLIST" 2>/dev/null \
+        || "$PB" -c "Add :EnvironmentVariables:AI_BRIEFING_TZ string $TZ_ARG" "$PLIST"
+    echo "  Timezone -> $TZ_ARG"
+fi
 
-# Unload existing agent (ignore errors if not loaded)
-launchctl unload "$PLIST_DEST" 2>/dev/null || true
+# -- Host-local anchor time ------------------------------------
+if [ -n "$HOUR" ]; then
+    if ! [[ "$HOUR" =~ ^[0-9]+$ ]] || [ "$((10#$HOUR))" -lt 0 ] || [ "$((10#$HOUR))" -gt 23 ]; then
+        echo "Invalid hour: $HOUR (must be 0-23)" >&2; exit 1
+    fi
+    MINUTE="${MINUTE:-0}"
+    if ! [[ "$MINUTE" =~ ^[0-9]+$ ]] || [ "$((10#$MINUTE))" -lt 0 ] || [ "$((10#$MINUTE))" -gt 59 ]; then
+        echo "Invalid minute: $MINUTE (must be 0-59)" >&2; exit 1
+    fi
+    # First StartCalendarInterval entry is the punctual anchor. Support both the
+    # array form (:0:) and a legacy single-dict form.
+    "$PB" -c "Set :StartCalendarInterval:0:Hour $((10#$HOUR))" "$PLIST" 2>/dev/null \
+        || "$PB" -c "Set :StartCalendarInterval:Hour $((10#$HOUR))" "$PLIST"
+    "$PB" -c "Set :StartCalendarInterval:0:Minute $((10#$MINUTE))" "$PLIST" 2>/dev/null \
+        || "$PB" -c "Set :StartCalendarInterval:Minute $((10#$MINUTE))" "$PLIST"
+    printf "  Host-local anchor -> %02d:%02d\n" "$((10#$HOUR))" "$((10#$MINUTE))"
+fi
 
-# Copy updated plist and reload
-cp "$PLIST_SRC" "$PLIST_DEST"
-launchctl load "$PLIST_DEST"
+# -- Validate & reload -----------------------------------------
+plutil -lint "$PLIST" >/dev/null
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
 
 echo "  Plist updated and agent reloaded."
 echo ""
-echo "  New schedule: daily at $(printf '%02d:%02d' "$HOUR" "$MINUTE")"
+echo "  Briefing fires at 08:00 in its timezone (default America/Los_Angeles)."
 echo "  Verify: launchctl list | grep ainews"
 echo ""

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
 
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -12,61 +12,61 @@
   <!-- Top-level docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/README.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/ARCHITECTURE.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/E2E_FLOW.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/SETUP.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/TESTS.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/PLUGINS.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/LOGS.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/CUSTOM_BRIEF.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_TEAMS.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_SLACK.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -74,19 +74,19 @@
   <!-- Eval harness docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/README.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/rubric.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/judge_prompt.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -94,13 +94,13 @@
   <!-- Plugin ecosystem -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/claude-plugins/README.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/plugins/README.md</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -108,13 +108,13 @@
   <!-- Discovery / SEO assets -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/llms.txt</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/humans.txt</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
Follow-up to #51 (which pinned the macOS run to 8 AM Pacific). This brings Windows to parity and documents the timezone knob.

## Changes

**`briefing.ps1` + `install-task.ps1` (Windows)**
- New `-Catchup` + `AI_BRIEFING_TZ` (default `Pacific Standard Time`; PS 7+ also accepts IANA ids). Task Scheduler fires in host-local time with no TZ field, so the task now repeats every 30 min and the Pacific guard posts exactly once per Pacific day on any host TZ — mirroring launchd's `StartInterval` + guard model. `MultipleInstances=IgnoreNew` prevents overlap. Unknown TZ ids fall back to host local.

**`scripts/update-schedule.sh` (macOS)**
- Rewritten with PlistBuddy: edits the **installed** plist in place (preserves webhook secrets — the old copy-from-repo clobbered them), array-aware, and adds `--tz ZONE` so macOS users set the zone in one command.

**Docs** — `README.md`, `SETUP.md`, `ARCHITECTURE.md`, `scripts/README.md`: document `AI_BRIEFING_TZ`, the 08:00-Pacific model on both platforms, and how to change the zone.

## Set a different timezone
```bash
# macOS
./scripts/update-schedule.sh --tz America/New_York
# Windows
setx AI_BRIEFING_TZ "Eastern Standard Time"
```

## Notes
- Includes a small `sitemap.xml` `lastmod` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)