### PR TITLE
docs: surface Power Automate as the Teams webhook delivery mechanism

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@
 ![Windows](https://img.shields.io/badge/Windows-Task_Scheduler-0078D4?logo=windsurf&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-Compatible-FCC624?logo=linux&logoColor=white)
 ![Teams](https://img.shields.io/badge/Microsoft_Teams-Webhook-6264A7?logo=microsoftteams&logoColor=white)
+![Power Automate](https://img.shields.io/badge/Power_Automate-Webhook-0066FF?logo=powerautomate&logoColor=white)
 ![Slack](https://img.shields.io/badge/Slack-Webhook-4A154B?logo=slack&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 ![Windows](https://img.shields.io/badge/Windows-Task_Scheduler-0078D4?logo=windsurf&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-Compatible-FCC624?logo=linux&logoColor=white)
 ![Teams](https://img.shields.io/badge/Microsoft_Teams-Webhook-6264A7?logo=microsoftteams&logoColor=white)
+![Power Automate](https://img.shields.io/badge/Power_Automate-Webhook-0066FF?logo=powerautomate&logoColor=white)
 ![Slack](https://img.shields.io/badge/Slack-Webhook-4A154B?logo=slack&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.x-3776AB?logo=python&logoColor=white)
 ![Make](https://img.shields.io/badge/Make-Cross_Platform-000000?logo=gnu&logoColor=white)

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI News Briefing - Automated Daily AI News Pipeline + Research Ops Ecosystem | Wiki</title>
   <meta name="description" content="Open-source automated daily AI news briefing pipeline. Multi-engine (Claude, Codex, Gemini, Copilot), 10-plugin research ops ecosystem, Notion + Teams + Slack + Obsidian delivery, custom topic deep research, 201 tests, and a 5-axis LLM-as-judge quality eval harness.">
-  <meta name="keywords" content="AI news briefing, automated AI news, Claude Code, Codex, Gemini CLI, Copilot CLI, Anthropic, OpenAI, agentic AI, multi-agent research, Notion MCP, Teams Adaptive Card, Slack Block Kit, Obsidian graph, knowledge graph, LLM-as-judge, eval harness, briefing automation, daily briefing, MCP server, plugin marketplace, deep research agent, research ops, hoangsonww">
+  <meta name="keywords" content="AI news briefing, automated AI news, Claude Code, Codex, Gemini CLI, Copilot CLI, Anthropic, OpenAI, agentic AI, multi-agent research, Notion MCP, Teams Adaptive Card, Power Automate webhook, Slack Block Kit, Obsidian graph, knowledge graph, LLM-as-judge, eval harness, briefing automation, daily briefing, MCP server, plugin marketplace, deep research agent, research ops, hoangsonww">
   <meta name="author" content="Son Nguyen (hoangsonww)">
   <meta name="copyright" content="© 2026 Son Nguyen - MIT License">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
@@ -80,7 +80,7 @@
         "runtimePlatform": ["macOS", "Linux", "Windows"],
         "operatingSystem": ["macOS", "Linux", "Windows"],
         "applicationCategory": "DeveloperApplication",
-        "keywords": "AI news, agentic AI, MCP, Claude Code, Codex, Gemini CLI, Notion, Teams, Slack, Obsidian, eval harness, LLM-as-judge, research ops",
+        "keywords": "AI news, agentic AI, MCP, Claude Code, Codex, Gemini CLI, Notion, Teams, Power Automate, Slack, Obsidian, eval harness, LLM-as-judge, research ops",
         "author": {
           "@id": "https://github.com/hoangsonww#person"
         },
@@ -231,6 +231,7 @@
       <span class="tech-tag c-blue">PowerShell</span>
       <span class="tech-tag c-green">Python</span>
       <span class="tech-tag c-purple">Microsoft Teams</span>
+      <span class="tech-tag c-cyan">Power Automate</span>
       <span class="tech-tag c-pink">Slack</span>
       <span class="tech-tag c-orange">macOS launchd</span>
       <span class="tech-tag c-cyan">Task Scheduler</span>
@@ -244,6 +245,7 @@
       <span class="tech-tag c-blue">PowerShell</span>
       <span class="tech-tag c-green">Python</span>
       <span class="tech-tag c-purple">Microsoft Teams</span>
+      <span class="tech-tag c-cyan">Power Automate</span>
       <span class="tech-tag c-pink">Slack</span>
       <span class="tech-tag c-orange">macOS launchd</span>
       <span class="tech-tag c-cyan">Task Scheduler</span>
@@ -433,7 +435,7 @@ sequenceDiagram
         <tr><td>Bootstrap</td><td>Date + environment</td><td>Prompt text + runtime context</td><td><code>briefing.sh</code>, <code>briefing.ps1</code></td></tr>
         <tr><td>Dedup</td><td><code>logs/covered-stories.txt</code> + latest Notion page</td><td>Exclusion list for this run</td><td>Step 0a (file) + Step 0b (Notion MCP)</td></tr>
         <tr><td>AI Run</td><td><code>prompt.md</code></td><td>Notion briefing + card.json + obsidian.md + covered-stories update</td><td>AI engine (Claude/Codex/Gemini/Copilot), WebSearch, Notion MCP</td></tr>
-        <tr><td>Teams Notify</td><td><code>logs/YYYY-MM-DD-card.json</code> + <code>AI_BRIEFING_TEAMS_WEBHOOK</code></td><td>Adaptive Card post(s)</td><td><code>notify-teams.sh</code>, <code>notify-teams.ps1</code></td></tr>
+        <tr><td>Teams Notify</td><td><code>logs/YYYY-MM-DD-card.json</code> + <code>AI_BRIEFING_TEAMS_WEBHOOK</code></td><td>Adaptive Card post(s) via Power Automate</td><td><code>notify-teams.sh</code>, <code>notify-teams.ps1</code></td></tr>
         <tr><td>Slack Notify</td><td><code>logs/YYYY-MM-DD-card.json</code> + <code>AI_BRIEFING_SLACK_WEBHOOK</code></td><td>Block Kit post(s)</td><td><code>notify-slack.sh</code>, <code>notify-slack.ps1</code>, <code>teams-to-slack.py</code></td></tr>
         <tr><td>Obsidian Publish</td><td><code>logs/YYYY-MM-DD-obsidian.md</code> + <code>AI_BRIEFING_OBSIDIAN_VAULT</code></td><td>Vault briefing page + topic stub pages</td><td><code>publish-obsidian.sh</code>, <code>publish-obsidian.ps1</code></td></tr>
         <tr><td>Multi-URL Routing</td><td>Semicolon-separated webhook URLs</td><td>First URL by default, all URLs with <code>--all</code>/<code>-All</code></td><td>Teams + Slack notify scripts</td></tr>
@@ -1417,7 +1419,7 @@ flowchart LR
     </div>
     <div class="feature-card">
       <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/NOTIFY_TEAMS.md">NOTIFY_TEAMS.md</a></h3>
-      <p>Teams webhook setup, multi-webhook configuration, Adaptive Card behavior, and troubleshooting delivery issues.</p>
+      <p>Power Automate webhook setup, multi-webhook configuration, Adaptive Card behavior, and troubleshooting delivery issues.</p>
     </div>
     <div class="feature-card">
       <h3><a href="https://github.com/hoangsonww/AI-News-Briefing/blob/main/scripts/teams-to-slack.py">scripts/teams-to-slack.py</a></h3>


### PR DESCRIPTION
## Summary
- Power Automate was undermentioned given its role: it's the required receiving side for Teams card delivery (legacy Incoming Webhook connector is deprecated), but only had a badge in `NOTIFY_TEAMS.md`.
- Added matching Power Automate badges to `README.md` and `ARCHITECTURE.md` next to the Teams badge.
- Surfaced it in `index.html`: hero marquee tech-tags, meta/JSON-LD keywords, delivery pipeline table row, and the `NOTIFY_TEAMS.md` doc-index card blurb.

## Test plan
- [x] Reviewed diffs for the three files; no functional/script changes, docs and landing page only.
- [ ] Visual check of `index.html` marquee/table rendering (docs-only change, low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJLyHLg5Codut87J4UzZa6