### PR TITLE
fix(seo): correct og:image dimensions and refresh sitemap lastmod dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
   <meta property="og:url" content="https://hoangsonww.github.io/AI-News-Briefing/">
   <meta property="og:image" content="https://hoangsonww.github.io/AI-News-Briefing/img/tests.png">
   <meta property="og:image:alt" content="AI News Briefing test runner CLI output banner">
-  <meta property="og:image:width" content="1280">
-  <meta property="og:image:height" content="720">
+  <meta property="og:image:width" content="1219">
+  <meta property="og:image:height" content="609">
   <meta property="og:locale" content="en_US">
   <meta property="article:author" content="https://github.com/hoangsonww">
   <meta property="article:publisher" content="https://github.com/hoangsonww">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
 
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -12,61 +12,61 @@
   <!-- Top-level docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/README.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/ARCHITECTURE.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/E2E_FLOW.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/SETUP.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/TESTS.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/PLUGINS.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/LOGS.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/CUSTOM_BRIEF.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_TEAMS.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/NOTIFY_SLACK.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -74,19 +74,19 @@
   <!-- Eval harness docs -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/README.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/rubric.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/eval/judge_prompt.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -94,13 +94,13 @@
   <!-- Plugin ecosystem -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/claude-plugins/README.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/plugins/README.md</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -108,13 +108,13 @@
   <!-- Discovery / SEO assets -->
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/llms.txt</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://hoangsonww.github.io/AI-News-Briefing/humans.txt</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
## Summary
- `og:image:width`/`og:image:height` declared **1280×720**, but `img/tests.png` (the actual og/twitter image) is **1219×609**. Verified with `file img/tests.png`. Fixed the meta tags to match reality -- a mismatched declared size can cause Facebook/LinkedIn/Twitter crawlers to mis-scale or discard the link-preview card.
- Refreshed all `lastmod` dates in `sitemap.xml` (2026-06-29 → 2026-08-30), following this repo's own periodic-refresh convention (see `6f2b581 chore(sitemap): bump lastmod dates to 2026-06-29`). Several landing/doc commits have shipped since the last bump.

## Test plan
- [x] `file img/tests.png` confirms actual dimensions (1219x609) match the new meta values.
- [x] `grep -c "2026-08-30" sitemap.xml` confirms all 18 `<lastmod>` entries updated.
- [ ] Spot-check the link preview on a social debugger (e.g. Facebook Sharing Debugger / Twitter Card Validator) after merge -- docs-only change, no functional risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJLyHLg5Codut87J4UzZa6